### PR TITLE
uncap music engine to 200 tracks

### DIFF
--- a/research/RESEARCH.md
+++ b/research/RESEARCH.md
@@ -197,6 +197,92 @@ heading. Every custom track is registered against the same cloned
 playback, only menu sorting and the album cover shown in some
 contexts.
 
+### LEA-relocation is a dead end (confirmed)
+
+Tried full LEA relocation of the slot table from +0x1970 to +0x4000
+with TWO different buffer allocators:
+
+1. VirtualAlloc'd buffer + LEA patches: crashed in `sub_14284ede0`
+   (jemalloc arena helper) at `buf & ~0x3FFFFF + 0x60`. VirtualAlloc
+   memory has no jemalloc chunk header, so when the engine handed a
+   pointer-into-our-buffer to the heap free path, jemalloc's
+   `addr & ~0x3FFFFF` chunk lookup hit unmapped memory.
+
+2. Game-allocator buffer (`sub_1400a18a0`) + LEA patches: crashed
+   IDENTICALLY at the same address with the same signature.
+
+Same crash signature with proper jemalloc chunks rules out buffer
+provenance as the root cause. The remaining hypothesis is the engine
+has implicit pointer arithmetic somewhere - probably
+`idx = (slot_ptr - &singleton[0x1970]) / 24` or
+`singleton = slot_ptr - 0x1970` style code. Patched LEAs change WHERE
+slot pointers come from, but unrelated arithmetic sites still assume
+the original `0x1970` offset and produce wildly wrong indices that
+get fed into other lookup tables, returning garbage pointers, eventually
+crashed by the heap free path.
+
+To proceed, would need to find every site doing that arithmetic. Sites
+look like `lea reg, [slot_ptr - 0x1970]`, `sub reg, 0x1970`, or
+computed-via-LEA negative offsets. They're scattered across multiple
+functions and not enumerable without exhaustive disassembly + careful
+testing. The buffer-redirect-via-game-allocator scaffolding stays in
+the code (gated behind `.extend_cap`) for future work but the LEA
+patch path is disabled.
+
+### Background notes (the steps that led to the dead end)
+
+Tried allocating a larger 0x6000-byte buffer via VirtualAlloc, redirecting
+the music engine ctor to use it, and patching all the
+`lea reg, [base+0x1970]` + `add reg, 0x960` instructions in
+sub_140c11d50 / sub_140c10d90 to relocate the slot table to +0x4000
+(well into the slack region).
+
+Buffer-redirect alone (no patches) ran cleanly. Adding the LEA patches
+crashed in `sub_14284ede0` (jemalloc arena helper) called from
+`sub_140c10d90`'s realloc path. Crash diagnostics:
+- Faulting address: our_buf base masked to 4MB alignment
+  (`buf & ~0x3FFFFF + 0x60`)
+- That's the jemalloc chunk-metadata location for our buffer's chunk
+- VirtualAlloc memory has NO jemalloc chunk header, so the read gets
+  garbage
+
+Two interlocking problems:
+
+1. **Buffer provenance** - the VirtualAlloc'd buffer has no jemalloc
+   metadata, so any code path that hands a pointer-into-our-buffer to
+   the heap (free, realloc) crashes when the heap looks up the arena.
+   Fix: allocate via the game's own allocator (`sub_1400a18a0`) instead
+   of VirtualAlloc - same heap, same arena, same metadata.
+
+2. **Implicit pointer arithmetic on table bases** - the music engine
+   may have code like `idx = (slot_ptr - &singleton[0x1970]) / 24` to
+   recover slot indices. We can patch the LEAs that LOAD the table base,
+   but this arithmetic might use the original `0x1970` baked into other
+   instructions (or computed via `lea + sub`). Relocating the table
+   would make those calculations produce wildly wrong indices that get
+   fed to other lookup tables, returning bogus pointers, eventually
+   crashing.
+
+Path forward:
+
+- Switch buffer allocator to `sub_1400a18a0` (sig already known). Test
+  if buffer redirect still works. If yes, jemalloc is happy.
+- Then attempt LEA patches with the proper allocator. If it STILL
+  crashes, problem #2 is real and the LEA-relocation strategy is doomed.
+- If problem #2 is real, switch to a hook approach: intercept the
+  slot-table-walking functions (sub_140c11d50, sub_140c10d90) entirely
+  and re-implement them with our own larger backing store. ~500 lines
+  of reimplementation but avoids implicit-arithmetic mismatches.
+- OR alternate cap dodge: intercept the music-engine "register track"
+  function (haven't found it yet) so only 100 tracks ever go through,
+  but they're swapped out at runtime as the user picks different tracks
+  in the player UI. "Paged" track set rather than truly extended cap.
+
+Knowledge captured: alloc site found, struct mapped (10440 bytes), all
+~50 cap immediates and 11 LEAs identified, jemalloc interaction
+diagnosed. Future work picks up at "switch allocator, attempt LEA
+patches, evaluate if pointer-arithmetic problem is real".
+
 ### The hardcoded 100-track cap (still working on it)
 
 The Wwise music engine has a 100-track total limit. OG game ships with
@@ -241,6 +327,246 @@ The path that needs implementing:
    change, alt-tab, save/load, music player UI) at >100 tracks - the
    bug only shows after a few bank loads, not immediately.
 
+#### Cap immediates and LEAs mapped so far
+
+Constructor `sub_140c0fef0` (only 5 LEAs total - clean):
+
+```
+140c0ff02  mov edi, 0x64                       ; MASTER COUNTER (reused twice)
+140c0ff07  mov ecx, edi                        ; first loop count = 100
+140c0ff0b  lea rax, [rbx+0x8]                  ; LEA: first table base+8
+                                               ; [loop fills 100 x 24B at +0x000]
+140c0ff3c  lea rcx, [rbx+0x960]                ; LEA: bucket array base
+140c0ff45  mov r8d, 0xfa0                      ; bucket array size (4000 bytes)
+                                               ; [memset(arg1+0x960, 0, 0xfa0)]
+140c0ff57  lea rax, [rbx+0x1970]               ; LEA: slot table base
+                                               ; [loop reuses rdi (still 100) - 100 x 24B]
+140c0ffc4  lea rcx, [rbx+0x22d0]               ; LEA: transition history base
+140c0ffcb  mov edx, 0x20                       ; transition history cap (32 entries)
+                                               ; [loop fills 32 x 40B at +0x22d0]
+```
+
+Trick: the constructor reuses `edi=0x64` as count for BOTH the first
+table (+0x000) and the slot table (+0x1970). Patching one immediate
+extends both. Convenient.
+
+Caller `sub_141eb9500` line 141ebae6e:
+
+```
+141ebae6e  void* rax_150 = sub_1400a18a0(0x28c8)        ; ALLOC SITE
+141ebae80  rbx_36 = sub_140c0fef0(rax_150)              ; ctor
+141ebae8b  data_146230fa8 = rbx_36                      ; assign global
+141ebae92  sub_140c14d70(rbx_36)                        ; post-init #1
+141ebae9f  sub_140c10300(rbx_36, sub_140c109f0(rbx_36)) ; post-init #2
+141ebaea7  sub_140c10880(rbx_36)                        ; post-init #3
+141ebaeaf  sub_140c10d90(rbx_36)                        ; post-init #4 - bucket fill
+141ebaeb7  sub_140c11ee0(rbx_36)                        ; post-init #5 - slot fill
+```
+
+Refcount/walk function `sub_140c11d50`:
+
+```
+140c11d6d  lea rdi, [rcx+0x1978]               ; LEA: slot table head (+8)
+140c11d74  mov esi, 0x64                       ; CAP: 100 iterations
+140c11dbc  lea rax, [rbp+0x1970]               ; LEA: slot table base
+140c11dc3  lea rdx, [rax+0x960]                ; LEA: end-of-table marker (size=100*24)
+```
+
+Bucket walk `sub_140c11fa0`:
+
+```
+140c11fdd  call sub_14017ebe0(arg3, 0x64)      ; alloc capacity hint (NOT a hard cap -
+                                               ;  array grows via sub_1400dcd20)
+140c11ff1  rdi = 9                             ; bucket idx capped at 9 (10 buckets)
+140c12001  lea i = (rdi+6)*0x190 + arg1        ; bucket base = arg1 + (rdi+6)*0x190
+140c1200e  while (i != &i[0x64])               ; CAP: 100 entries per bucket
+```
+
+Bucket-walk + slot-update function `sub_140c12320` (heavily unrolled,
+~17 cap immediates):
+
+```
+140c12330  mov eax, [rcx+0x1900]               ; load current bucket idx (0..9)
+140c12351  cmovg eax, ecx                      ; cap at 9
+140c1235d  imul rax, rax, 0x190                ; bucket stride (400)
+140c123d6  add rax, 0x968                      ; bucket base = arg1 + idx*0x190 + 0x968
+                                               ;   (with imul output already including arg1)
+140c123ea  cmp r11, 0x63                       ; CAP CHECK x16 in unrolled body
+140c1240b  ja 0x140c12410                      ;   (each branch with `cmp r11, 0x63` /
+140c12407  cmp r11, 0x63                       ;    `cmp ecx, 0x64` repeated)
+... [16 more cap branches in 8-element-unrolled copy loop]
+140c125ba  cmp r11, 0x64                       ; OUTER LOOP CAP
+
+140c125c4  mov r8, [r9+0x1940]                 ; +0x1940 = a state pointer
+140c125cb  movsxd rax, [r9+0x1938]             ; +0x1938 = a state count
+140c125d2  imul rdi, rax, 0x38                 ; 56-byte stride iteration
+140c12631  add r8, 0x38                        ; iterates through 56-byte entries
+140c1265b  lea rcx, [r9+0x1930]                ; LEA: another field
+140c12688  lea rcx, [r9+0x1930]                ; (same)
+140c126b1  mov [r9+0x1930], ebx                ; writes to +0x1930
+140c126c8  jmp 0x140c12120                     ; tail-call to dynamic-array helper
+```
+
+Note: the `0x190 + 0x968` pattern in `sub_140c12320` is the bucket
+base formula: `arg1 + bucket_idx*0x190 + 0x968`. The formula assumes
+buckets are 0x190 (400) bytes each starting at +0x968. Patching to
+support more entries per bucket changes 0x190.
+
+Total enforcement points found so far:
+
+| Function       | Cap immediates | Tables touched (LEA / arith)        |
+|----------------|----------------|-------------------------------------|
+| sub_140c0fef0 (ctor)   | 1 (master 0x64) + 1 (0x20)| 4 LEAs: +0x008, +0x960, +0x1970, +0x22d0 |
+| sub_140c14d70 (post-init) | 2 (i_2/i_3=0xa) + ~10 unrolled blocks | inline writes, no relocation possible |
+| sub_140c10d90 (post-init) | ~20 (mix 0x64/0x63 + outer 0xa) | 3 walks of slot table, 1 walk of bucket array, allocates per-bucket via sub_1400b69a0(0x190) |
+| sub_140c11d50 (refcount walk) | 1 (0x64) | 3 LEAs: +0x1970, +0x1978, +0x960 size |
+| sub_140c11fa0 (bucket walker) | 1 walk (0x64) + 1 alloc hint | 1 imul-based bucket compute |
+| sub_140c12320 (unrolled copy) | ~17 (mix 0x64/0x63) | imul+add for buckets, 9 LEA-like base computations |
+| sub_140c11ee0 (post-init #5) | 0 (uses dyn arrays at +0x1948) | walks +0x1940 array (38B stride - separate structure) |
+| sub_140c11fa0 callees... | TBD | TBD |
+
+Conservative total: **~50 cap immediates + 11 LEAs** across the
+post-init and runtime functions. Plus whatever lives in
+sub_140c10300, sub_140c10880, sub_140c109f0 (also called from the
+init sequence at sub_141eb9500).
+
+Critical detail learned from `sub_140c14d70`: the first table at
++0x000 is initialized via **10 nested unrolled wmemcpy blocks per
+outer iteration** (10 outer × 10 unrolled = 100 entries). Extending
+this past 100 isn't a single immediate patch - the unrolling is
+structural. Same for several other init paths.
+
+Critical detail from `sub_140c10d90`: the slot table at +0x1970 is
+walked **THREE times** in this single function via the pattern
+`lea rax, [rcx+0x1970]; add rcx, 0x960; while (rax != rcx) ... rax
++= 0x18`. The 0x960 is the END pointer (100*24). To extend the slot
+table we'd need to patch 0x960 → larger AND ensure the table physically
+extends to the new boundary.
+
+Strategy options ranked from simplest to most invasive:
+
+A. **Just patch the 1 master 0x64 in the constructor** to a smaller
+   value (e.g., 0x32 = 50) and see what happens. Safe experiment - if
+   the engine then crashes at 50 tracks, that proves the constructor's
+   cap matters and the other immediates need patching too. If it still
+   works at 100, the constructor cap is just for init scope and other
+   walks self-limit.
+
+B. **Hook sub_1400a18a0(0x28c8)** to allocate larger but DON'T move
+   tables - just enlarges trailing slack. Patch ONLY the master 0x64
+   in the constructor + the 2 caps in sub_140c11d50. Tables grow into
+   adjacent state regions (corrupting them) but maybe specific
+   downstream code doesn't care if those state fields are nonzero.
+   High crash risk but quick experiment.
+
+C. **Full relocation**: Hook alloc to enlarge, move all 3 tables to
+   trailing slack, patch every LEA + every cap immediate. Multi-day,
+   high test burden, real fix.
+
+Trick option D: **two-stage cap**. Keep tables at 100 cap. Make the
+mod's InjectCustomTracks register only 42 customs with the music
+engine but show ALL custom tracks in the AllTracks UI list. When user
+clicks track 43+, swap a registered slot to point at the requested
+track at runtime. Effectively a paged cache. Loses state of the
+swapped-out track but keeps unlimited library. Worth considering as
+an alternative to the relocation.
+
+#### Corruption mechanism - working theory
+
+The engine's allocator `sub_1400a18a0` is the GAME-WIDE allocator
+called from thousands of places (390KB of xrefs). Cannot hook safely.
+Cleaner intercept is `sub_140c0fef0` (the constructor) called once
+with the 0x28c8 buffer.
+
+The +0x1918 pointer that crashes is written by `sub_140c14480` line
+140c14699: `*(rdi+0x1918) = sub_140ac64d0(...)`. `sub_140ac64d0`
+internally calls `sub_14268afb0(data_14a1a1020, 0, arg1, 0)` and
+returns the result. So the corruption could be either:
+
+1. `sub_14268afb0` returns garbage when arg1 is something the engine
+   can't resolve (e.g., a music context for a track that doesn't fit
+   in the 100-bucket lookup).
+2. Some other code writes garbage directly to +0x1918 (haven't found
+   such a write yet).
+
+The bucket arrays at +0x968 hold 10 x 100 uint32 IDs. With 101 OG+
+custom tracks, only 100 fit in the bucket. Track lookup queries the
+bucket; with one missing track, the lookup returns null/garbage. If
+the music engine doesn't null-check the lookup result, garbage gets
+written to +0x1918 and crashes later.
+
+Ramifications:
+
+- The 100-cap isn't really a "table cap" - it's a lookup table cap.
+- Extending requires either bigger buckets (per-bucket cap > 100) OR
+  more buckets (count > 10) OR both.
+- The bucket walks (sub_140c11fa0 etc.) use `while (i != &i[0x64])`
+  where 0x64 is element count for bucket scan (= 400 bytes of int32s).
+  Extending buckets means patching this immediate AND making each
+  bucket physically larger.
+- The 32-entry transition history at +0x22D0 is unrelated to track
+  count - it's a runtime state buffer. Doesn't need extension.
+
+Cleanest concrete attempt path:
+
+```cpp
+// Hook sub_140c0fef0 (the music engine ctor).
+// Original signature: ctor(void* buf_0x28c8) -> void* singleton.
+// Sig: 48 89 5c 24 08 48 89 74 24 10 57 48 83 ec 20 48 8b d9 bf 64 00 00 00 8b cf 33 f6 48 8d 43 08
+
+static void* __cdecl Hook_MusicCtor(void* origBuf) {
+    // 1. Allocate larger buffer (+ trailing slack for relocated tables)
+    void* big = VirtualAlloc(nullptr, 0x6000, MEM_COMMIT|MEM_RESERVE,
+                             PAGE_READWRITE);
+    if (!big) return g_origMusicCtor(origBuf); // graceful fallback
+
+    // 2. Run original constructor on our larger buffer (it inits the
+    //    standard 0x28c8 region, leaving trailing 0x3738 untouched).
+    void* ret = g_origMusicCtor(big);
+
+    // 3. Patch in-place: the cap immediates and LEAs in this same
+    //    function and the runtime walkers. Done via sig-scanned
+    //    addresses + VirtualProtect + byte writes.
+    //    Specifically:
+    //      sub_140c0fef0 +0x12: BF 64 00 00 00 -> BF C8 00 00 00 (master 200)
+    //      sub_140c0fef0 +0xDB: BA 20 00 00 00 (transition history cap, may stay)
+    //      sub_140c0fef0 +0xCD: 48 8D 8B D0 22 00 00 -> relocate to +0x4000
+    //                                                  (transition history relocated
+    //                                                   to slack, freeing +0x22D0)
+    //      sub_140c11d50 +0x24: BE 64 00 00 00 -> BE C8 00 00 00 (walk cap 200)
+    //      sub_140c11d50 +0x73: 48 8D 90 60 09 00 00 -> 48 8D 90 C0 12 00 00 (size 0x12C0 = 200*24)
+    //      sub_140c10d90: 3 slot-table walks need same cap+size patches
+    //      sub_140c12320: heavily unrolled, ~17 cap immediates - skip first pass
+    //      sub_140c11fa0: bucket cap 0x64 stays for now (only extending slot table)
+
+    // 4. (Optional) Free the orig buf - but we don't know the right
+    //    deallocator. Leak it for now (10440 bytes, one-time cost).
+    return ret;
+}
+```
+
+Risks for the first attempt:
+
+- Sub_140c12320 is heavy unrolled with ~17 0x64 caps; if NOT patched,
+  it'll continue treating the slot table as 100-entry and will skip
+  rows 100-199. That's tolerable for read but BAD if it does writes.
+- The first table at +0x000 also has a 100-cap (uses the same master
+  0x64 in ctor). Patching master to 200 also extends THAT table -
+  which would then write past +0x960 into bucket region (bucket
+  region gets memset right after, so first-table extension is wiped).
+  Net effect: first table effectively only has 100 entries even if we
+  ask for 200. Probably fine since the first table isn't directly
+  involved in the crash mechanism.
+- Bucket arrays stay at 100/bucket. If the 101st track lookup goes to
+  buckets, it still won't find the track and returns garbage. So
+  extending JUST the slot table might not actually fix the crash.
+- The bucket lookup needs separate attention. We may need to extend
+  bucket count (10 -> 20+) or per-bucket size (100 -> 200) too.
+
+Verdict: even the minimal viable attempt has multiple correlated
+patches with uncertain side effects. Each iteration needs in-game
+testing because the bug only manifests after a few bank loads.
+
 Failed attempts that got recorded so they don't get retried:
 
 - **Self-hosting the MRSC parent** (clone OG `CAkMusicSwitchCntr`
@@ -258,6 +584,867 @@ Failed attempts that got recorded so they don't get retried:
   like MinHook trampoline interaction or a static-local init guard
   in the dump helper. Worked fine when called from the existing
   `InjectCustomTracks` PRE/POST checkpoints.
+
+#### Slot table populator: `sub_140c10c50` (the actual root cause)
+
+After re-reading the disasm with fresh eyes, the corruption mechanism
+is much simpler than the bucket-overflow theory above. The slot table
+at `+0x1970` is populated by `sub_140c10c50`. Its loop body:
+
+```
+0x140c10d24:  lea r8, [rcx+0x1970]        ; r8 = slot_table_base
+0x140c10d30:  mov rcx, [r9]                ; rcx = current TrackResource ptr
+0x140c10d33:  test rcx, rcx                ; null check
+0x140c10d3f:  mov eax, [rcx+0x20]          ; eax = track id (uint32)
+0x140c10d49:  mov [r8],     eax            ; slot[+0]    = track id (lo32)
+0x140c10d4c:  mov [r8+0x8], rcx            ; slot[+8]    = track ptr
+0x140c10d50:  mov [r8+0x10], rdx           ; slot[+0x10] = first-table self-ptr
+0x140c10d54:  mov [rdx],    eax            ; first_table[i] = track id
+0x140c10d7d:  add r8, 0x18                 ; slot += 24
+0x140c10d81:  add r9, 0x8                  ; track++
+0x140c10d85:  cmp r9, r10                  ; r10 = array_end (count-bounded)
+0x140c10d88:  jne 0x140c10d30
+```
+
+**There is no cap check on `r8`.** The loop iterates the full OG
+TrackResource array and writes one slot per entry. The OG array has
+58 entries by default; with our `InjectCustomTracks` extension to
+142, the loop writes 142 slot entries.
+
+The slot table region between `+0x1970` and `+0x22D0` only holds 100
+entries (100*24 = 0x960). Slot writes 100..141 (= our custom slots
+42..83) spill into the **transition history at `+0x22D0`** (32
+entries, 40 bytes each).
+
+Because slot stride (24) and transition stride (40) are coprime, the
+spilled slot writes land at misaligned positions inside transition
+entries. The Ref<T> field at `transition[N]+0x18` (the destructor
+target zeroed via `sub_1400ba3c0` from `sub_140c109f0`) ends up
+holding partially-overwritten bytes - sometimes a real cloned-resource
+pointer (works), sometimes the upper 32 bits of one slot's fields
+merged with adjacent data, which materializes as `0xAD......` or
+`0x00000000xxxxxxxx`-shaped garbage that AVs when dereferenced as a
+vtable pointer at +0x90.
+
+This is the crash we've been chasing. The dtor-router shim on
+`sub_1400ba3c0` only catches the cases where the +8 field cleanly
+holds a custom ID; misaligned partial overwrites leak through with
+non-`AD8` patterns and AV in the obfuscated dispatcher.
+
+##### Why the existing hard-cap-at-42 release works
+
+`InjectCustomTracks` caps customs at `MUSIC_ENGINE_TRACK_CAP - 58 = 42`.
+With 100 total tracks, `sub_140c10c50` writes exactly 100 slots, fills
+the slot table to the boundary at `+0x22D0`, and never spills into the
+transition history. No corruption.
+
+##### Concrete fix paths (in order of cost)
+
+1. **Hook `sub_140c10c50` and add a 100-iter cap.** Same outcome as
+   the release version (only first 100 tracks playable) but the
+   experimental branch's 200-cap upstream becomes safe to enable
+   without crashing the engine. Customs in slots 100+ show in the UI
+   but won't play through the slot-routed dispatch. Trivial. ~10 lines.
+
+2. **Hook `sub_140c10c50` and rewrite the loop to write to a
+   relocated 200-slot table** (in trailing slack at e.g. `+0x4000`).
+   Then patch every other site that reads the slot table to use the
+   new base. The reader sites we know:
+   - `sub_140c10d90`  (bucket fill: `lea ..., [rdi+0x1970]` and ends
+     at `+0x960`; iterates 100 in inner loop)
+   - `sub_140c11d50`  (slot walk: `arg1+0x1978` plus `+0x1970` and
+     `+0x960`, count `0x64`)
+   - `sub_140c10c50`  (the populator itself - rewrite via hook)
+   - Plus the `r8 - 0x1970` recovery in the populator that writes
+     `first_table[i]` - need to keep that delta consistent or skip
+     the first-table writes entirely.
+   - Plus the 32-entry transition history INIT in `sub_140c109f0`
+     at `arg1 + 0x22e8 + i*0x28` - this stays at +0x22D0; it's not
+     part of the slot table, just adjacent.
+   This is the real path forward but is the LEA-relocation work the
+   prior section concluded was hard. The new finding makes it easier
+   because we now know we ONLY need to relocate the slot table, not
+   also the bucket arrays (the bucket caps come from the populator's
+   slot_index, so if the populator runs, buckets get filled without
+   needing larger size).
+
+3. **Reimplement `sub_140c10c50` in our hook to write to BOTH a
+   relocated 200-entry table AND maintain the original 100-entry
+   table for the readers we don't patch.** Most invasive but
+   minimizes patch surface. Probably overkill.
+
+Recommended next step: do (1) immediately so the experimental branch
+stops crashing on 142 tracks. That gives us a working baseline to
+iterate (2) on top of.
+
+##### `sub_140c10c50` xrefs (for hooking)
+
+- Called from `sub_140c109f0` at `+0x10a32`. This is the music engine
+  init path. `sub_140c109f0` immediately follows the populator with
+  a 32-iteration loop calling `sub_1400ba3c0(transition[i]+0x18, 0)`
+  and `sub_1400ba3c0(transition[i]+0x28, 0)` to destroy any pre-
+  existing Ref<T> in the transition history. With our spilled slot
+  writes corrupting the transition region, those destructor calls
+  see partial overwrites and AV.
+- Called from `sub_141ebc650` at `+0x1ebda70`. This is an event/state-
+  machine handler (massive function, 9-case switch) - one case path
+  performs a full music engine refresh: `sub_140c10c50` →
+  `sub_140c10d90` (bucket fill) → `sub_140c11ee0` → `sub_140c12090` →
+  `sub_140c12120` (playlist shuffle). Same spill problem applies
+  here. Probably triggered by save-load / scene change / similar
+  state-reset events.
+
+Both callers pass the singleton pointer (`data_146230fa8` typically,
+or via `rsi`/`rbx_42` after singleton getter). Hook target is
+`sub_140c10c50` itself - both call sites then become safe.
+
+Sig for `sub_140c10c50` prologue: `4C 8B 05 ?? ?? ?? ?? 4D 85 C0 0F 84 ?? ?? ?? ?? 48 8D 81 98 19 00 00 BA 0A 00 00 00`
+
+##### Sister-corruption: the first table at `+0x000`
+
+`sub_140c10c50` ALSO writes `first_table[i] = track_id` via
+`mov [rdx], eax` where `rdx = r8 - 0x1970` (= singleton + i*24, the
+first 24-byte-per-entry table at `+0x000`). The first table is sized
+for 100 entries (ends at `+0x960`), and writes for i>=100 spill into
+the **bucket array at `+0x968`**. So for each spilled slot we corrupt
+TWO regions: transition history at `+0x22D0+` and bucket array at
+`+0x968+`. The corrupted bucket array then makes downstream bucket
+lookups return our custom IDs as if they were real slot indices,
+which gets dereferenced as object pointers and AVs.
+
+This compounds the failure modes. A simple iteration cap on the
+populator fixes both at once because nothing past slot 99 gets
+written.
+
+##### Singleton layout (full map, post sub_140c0fef0 ctor)
+
+Confirmed by reading the ctor disassembly end-to-end:
+
+```
++0x0000 - +0x0960  First table  (100 × 24B)
++0x0960 - +0x1900  Bucket array (10 pages × 100 × 4B = 10 × 0x190)
++0x1900 - +0x1910  Small scalar headers (page idx, magic 0x46, etc)
++0x1910 - +0x1938  More scalars (current track, runtime state)
++0x1938 - +0x1968  0x30-byte "current playback" struct
++0x1968 - +0x1970  scalar
++0x1970 - +0x22D0  Slot table   (100 × 24B)              <-- target for extension
++0x22D0 - +0x27D0  Transition history (32 × 40B)
++0x27D0 - +0x28C8  Tail state (current track ref/refs, SRW, etc)
+```
+
+Total ctor-initialized = 0x28C8 (the original buffer size we observed).
+
+The slot table and first table are **coupled**: each slot at
+`+0x1970+i*24` has its `+0x10` field point to the corresponding
+first-table entry at `+0x000+i*24`. The bucket array at `+0x968+`
+stores `track_id` values per bucket page (10 pages × 100 entries),
+used as a hash-table-style lookup to find tracks by id.
+
+##### Save-game compatibility constraint
+
+`sub_140714000` is the music-state save-game serializer (called
+during the global save flow at `+0x140714e37` + `+0x140714e5d`).
+It does:
+```
+(*(*rcx_137 + 8))(rcx_137, rbx_20, 0x1910)   // write 0x1910 bytes
+sub_140c11d50(rbx_20)                          // walk slots
+```
+
+So the saved blob is **the first 0x1910 bytes** of the singleton:
+first table + bucket array + a few scalars. The slot table at
+`+0x1970+` is NOT in the save - it's rebuilt from the OG track
+resource array via `sub_140c10c50` on every game launch / save
+load.
+
+`sub_140c15080` is the corresponding loader. It reads back the
+0x1910 byte block, then walks each entry to recover slot
+back-pointers (the heavy unrolled `j s< 0x64` loops at lines
+`+0x140c159...+0x140c15c..`).
+
+**Implication for extending:**
+- Slot table can be extended to 200 entries in trailing slack
+  WITHOUT breaking save compat (it's rebuilt every load anyway).
+- First table CANNOT be extended in place - its size is baked into
+  the 0x1910 save blob. Extending breaks save backward compatibility.
+- Bucket array same story (it's part of the 0x1910 blob).
+
+So a save-compatible uncap leaves the first table and bucket array
+at 100 entries and only widens the slot table. Slots 100..199 would
+not have first-table back-pointers (slot+0x10 = NULL or unused) and
+would not be findable via bucket lookup.
+
+That's an open architectural question: does the music player UI
+dispatch play via direct track-resource pointer (so slots 100..199
+work fine), or via bucket-id lookup (so they don't)? Need to trace
+the click→play path to know. Suspect the former because the player
+already iterates the track resource array directly to render the
+list, so it has the resource pointer in hand at click time.
+
+##### Complete site enumeration for slot-table extension
+
+Patch displacement `0x1970` → new slot-table base
+(suggested `+0x4000` in the 0x6000 buffer):
+
+| Function          | Offset(s) | Asm pattern                              |
+|-------------------|-----------|------------------------------------------|
+| `sub_140c0fef0`   | +0x67     | `lea rax, [arg1+0x1970]` (ctor init)     |
+| `sub_140c10c50`   | +0xD4     | `lea r8,  [rcx+0x1970]` (populator)      |
+| `sub_140c10c50`   | +0xF2     | `lea rdx, [r8-0x1970]`  (back-ptr calc)  |
+| `sub_140c10d90`   | x3 sites  | slot-table base loads (bucket fill)      |
+| `sub_140c11d50`   | +0x1D     | `lea rdi, [arg1+0x1978]` (= base+8)      |
+| `sub_140c11d50`   | +0x6C     | `lea rax, [arg1+0x1970]`                 |
+| `sub_140c15080`   | x10+      | slot-table base loads in load-game unroll|
+
+Patch immediate `0x960` → new slot-table size (`0x12C0` for 200 entries):
+
+| Function          | Pattern                                       |
+|-------------------|-----------------------------------------------|
+| `sub_140c11d50`   | `lea rdx_1, [rax+0x960]` (end calc)           |
+| `sub_140c10d90`   | end calc(s) for inner walk loop               |
+
+Patch immediate `0x64` → new slot count (`0xC8` for 200):
+
+| Function          | Sites | Notes                                       |
+|-------------------|-------|---------------------------------------------|
+| `sub_140c0fef0`   | x2    | `i_5=0x64` and `i_3=0x64` (init two tables) |
+| `sub_140c10d90`   | x1+   | inner slot walk bound                       |
+| `sub_140c11d50`   | x1    | `rsi = 0x64`                                |
+| `sub_140c12120`   | x1    | `sub_14017ebe0(arg1+0x1958, 0x64)` - vector |
+|                   |       | resize cap; semantics unclear, may stay     |
+| `sub_140c15080`   | x10   | one per per-page load loop (j s< 0x64)      |
+
+What stays untouched (because save compat / orthogonal to slot table):
+- `sub_140c12320` (playlist copy, 17 caps - bucket-page-sized, not
+  slot-count-sized)
+- Bucket array layout (10 pages × 100 × 4B, sized 0xFA0) - keeps OG
+  size, only first 100 slots get bucket entries
+- First table at `+0x000` - keeps 100 entries
+- Transition history, tail state - unrelated to track count
+
+##### The save compat path forward
+
+Architecture:
+1. Hook `sub_140c10c50` to write to relocated slot table at
+   `+0x4000`. Cap output at 200. For slots 0..99, ALSO write the
+   first-table entries at `+0x000+i*24` (preserves OG behavior for
+   readers that only know about the first table). For slots
+   100..199, skip first-table write (out of bounds) and skip the
+   `slot+0x10 = first_table[i]` self-pointer (set to NULL or to a
+   harmless dummy).
+2. Hook `sub_140c10d90` (bucket fill) and `sub_140c11d50` (slot
+   walk) to use the relocated base + extended cap. Bucket fill
+   would still only emit bucket entries for slots 0..99 (because
+   bucket page size is 100 and we're not extending it). Slots
+   100..199 are visible to the slot walker but not bucket-lookupable.
+3. Save game: still writes 0x1910 byte block (unchanged). Saves
+   created with our extension are backward-compatible with stock.
+4. Load game: hook `sub_140c15080` only if needed - the load path
+   already calls `sub_140c10c50` which we hook, so the slot table
+   gets repopulated correctly post-load.
+
+Rather than patching N sites of the original functions, we
+re-implement them in our hooks. That's ~150 lines of C++ but each
+function is small, and we sidestep the displacement-encoding
+mechanics entirely.
+
+##### Click→play path: SLOT-RESOLVED, not direct (decided)
+
+Traced via `sub_140c126e0` (music engine state-machine tick at
++0x140c126e0, reads `data_146230f88` 4 times). It maintains a
+"current playback queue" at:
+- `singleton + 0x1938`: count
+- `singleton + 0x1940`: pointer to entries (56B each)
+- `singleton + 0x1948`: ID array count
+- `singleton + 0x1950`: pointer to int32 ID array
+- `singleton + 0x1924`: currently-selected track id
+
+The play loop iterates `+0x1940` looking for `*(entry+0x10)+0x20`
+matching `*(*(rdi+0x1950) + idx*4)`. The `+0x1940` entries are
+populated by `sub_140c10d90` (bucket fill) FROM the slot table at
++0x1970. So:
+
+```
+slot_table[i]            -> populated by sub_140c10c50 from trackArr
++0x1940 playback queue   -> populated by sub_140c10d90 from slot_table
++0x1924 selected id      -> set by user click via state machine
+play tick                -> walks +0x1940 looking for selected id
+```
+
+If slots 100..199 are empty (because we hard-cap the populator
+at 100), `sub_140c10d90` skips them, no playback queue entries
+exist for those tracks, and the play tick can't find them when
+selected. **Customs at trackArr index 100+ won't play through
+the music player UI.**
+
+##### Path forward (decided)
+
+The cheap cap-hook fix (currently in place on this branch) stops
+the corruption crash so users can run extend_cap with > 42 customs
+without the engine destroying itself. But customs 43..N (N=84 at
+file count) will appear in the UI and not play - confusing UX.
+
+For actual >100 PLAYABLE customs, the slot table must be relocated
+to trailing slack with capacity 200 AND `sub_140c10d90` /
+`sub_140c11d50` must be hooked to walk the relocated table. The
+patch surface is enumerated above. ~150 lines of hook code, all
+mechanical work after the architecture is settled.
+
+Recommended order:
+1. **Test the current cap-hook build** with 84 tracks loaded.
+   Confirms the corruption is fixed (game doesn't crash, doesn't
+   freeze, doesn't black-screen).
+2. **If 1 works**: customs 43..84 will appear in UI but not play.
+   That's expected. Now we know the cap-hook is safe to ship as a
+   "safety net" so future big libraries don't crash even if the
+   real fix isn't done yet.
+3. **Then start the relocation work**: hook `sub_140c10c50` to
+   write to `+0x4000` instead of `+0x1970` (200 slot capacity),
+   hook `sub_140c10d90` to walk the relocated table (200 inner-
+   iter cap), hook `sub_140c11d50` similarly. The save-compat is
+   preserved because none of these touch the +0x000..+0x1910
+   region that gets serialized.
+4. **Edge cases to handle in the hooks**:
+   - `slot[i].back_ptr` (slot+0x10) for i>=100 should be NULL
+     since first table doesn't have entries past 99 (preserves
+     save compat). Bucket fill checks `if (rdx_1 != 0)` so this
+     is safe.
+   - Bucket array stays 100-entry (not extended). Bucket lookups
+     keyed by track id can only point to slots 0..99. Need to
+     understand if `+0x1940` queue size matters - it's `*0x38`
+     stride, count from `+0x1938`, dynamically sized. Should
+     accommodate 200 entries fine if `sub_140c10d90` writes
+     them all.
+   - The save game's `+0x1910` byte block doesn't include slot
+     table or playback queue - both are rebuilt every load. So
+     slot table relocation has zero save-compat impact.
+
+##### Status
+
+Cap-hook on `sub_140c10c50` is in working tree - safety net so the
+engine doesn't crash with > 100 trackArr entries. Real fix is the
+slot-table relocation: hook `sub_140c10c50` to write to `+0x4000`
+instead of `+0x1970` (200 capacity), hook `sub_140c10d90` and
+`sub_140c11d50` to walk the relocated table. None of it touches
+the save-compat region (+0x0000..+0x1910), so existing saves keep
+working. ~150 lines of hook code total.
+
+##### Stage 2 in-game test results (2025-05-05)
+
+Stage 2 tested live with 84 customs:
+- All 21 byte patches landed cleanly.
+- `slot-populator(reloc): wrote 142 slots at sing+0x4000 (origCount=142)` - all
+  142 entries (58 OG + 84 customs) populated into the relocated table.
+- Engine reads from `+0x4000` correctly via the patched bucket-fill;
+  every track played through the music player UI produced a clean
+  PE → playingId without errors.
+- No crash, no hang, ~10 minutes of gameplay including combat and
+  save/load cycles. Clean log.
+
+Open question: **the music player UI may not be exposing tracks at
+trackArr index 100+ (= our customs[42..83])**. The user couldn't find
+"Gorillaz Pirate Radio Take Over (6)" (custom[83]) in the in-game
+list, even though it's loaded into trackArr at index 141, has full
+metadata (title, duration=132s, sound resource, MenuDisplayPriority
+30083), and is in the relocated slot table.
+
+**Most likely explanation: bucket array overflow.**
+
+The bucket array at `+0x968` is 10 pages × 100 entries × 4B
+(= 0xFA0 bytes, baked into the save-game blob layout - we don't
+extend it). Bucket-fill in `sub_140c10d90` walks the slot table
+and emits one bucket entry per slot, with a `cmp esi, 0x64; jge`
+per-page cap that stops at 100 entries per page.
+
+After our slot-table relocation:
+- Slot table at `+0x4000` holds 200 entries (all 142 tracks).
+- Bucket-fill walks all 142 entries.
+- Per-page cap of 100 means bucket entries are emitted only for
+  the first 100 tracks across all pages. Tracks 100..141 (=
+  trackArr indices) get NO bucket entries.
+
+Mapping: customs are appended after OG tracks, so:
+- trackArr[0..57]   = OG (always have bucket entries)
+- trackArr[58..99]  = customs[0..41]  (have bucket entries)
+- trackArr[100..141] = customs[42..83] (NO bucket entries)
+
+If the music player UI's track-listing or click-to-play resolves
+via the bucket array (likely - it's the engine's primary lookup
+table by track id), customs at index 42+ would be invisible /
+non-clickable. This **exactly matches the observed behavior**:
+custom[34] visible+playable, custom[83] not findable.
+
+Verifications to do next session:
+- Add diagnostic log to `sub_140c10d90` hook output: dump bucket
+  array entries post-fill, count how many our customs got slots.
+- Decompile any function that reads bucket-array entries by track
+  id (search xrefs to displacement +0x968 within the engine
+  cluster) - confirm UI uses bucket lookup.
+
+##### Fix paths for bucket array
+
+Same 3-tier escalation as the slot table:
+1. **Relocate the bucket array too.** Move from `+0x968` to
+   somewhere in slack (+0x5000 say) with 200 entries per page
+   (10 × 200 × 4 = 0x1F40 bytes). Patch every reader that uses
+   the `+0x968` displacement OR the `+0x190` per-page stride.
+   Per-page cap immediates (`cmp esi, 0x64`) need bumping too -
+   and they're imm8 sign-extended so we hit the same encoding
+   problem we hit with the slot walk in section 3 (need imm32
+   form, can't fix in place without longer encoding).
+2. **Hook the bucket lookup function** and reimplement in C.
+   Slower lookup (O(N) instead of O(1)) but flexible.
+3. **Increase per-page count, decrease page count.** Keep the
+   total bucket array size the same (0xFA0). Use 5 pages × 200
+   entries = same 0xFA0 bytes. Avoids relocation but requires
+   patching the page-stride (+0x190 → +0x320) and per-page cap
+   sites. Might still hit the imm8/imm32 encoding wall.
+4. **Just don't hide tracks.** Hook the music player UI's track-
+   listing function directly and bypass bucket lookup entirely.
+   Most invasive but cleanest.
+
+Recommended: option 2 (hook + reimplement bucket lookup). The
+bucket lookup is one specific function with a defined signature.
+Reimplementing it as O(N) walk over the 200-slot table is a
+~30-line hook.
+
+Next session priority: identify the bucket-lookup function from
+xrefs to data_146230fa8 + read of bucket entries at `+0x968+
+page*0x190 + idx*4`.
+
+##### Other unverified theories for the UI invisibility
+
+The bucket-overflow theory above is the strongest match but
+unverified. Other plausible theories worth eliminating before
+spending hooks on bucket extension:
+
+- **DSCatalogueRewardResource gate.** Each OG track has a
+  CatalogueRewardResource that ties to the music-player UI's
+  unlock list. Our custom TrackResources aren't registered in
+  any CatalogueRewardResource. If the UI lists tracks via
+  CatalogueRewardResource, only OG would show - but the user
+  CAN see custom[34], so this likely isn't a hard gate. Maybe
+  a partial filter (some UI mode shows trackArr, another shows
+  Catalogue list).
+
+- **Some unset byte field in our cloned TrackResource.** The
+  resource is 0x300 bytes copied from source; we override
+  TrackId / Seconds / MenuDisplayPriority / Flag / TitleText /
+  OpenConditionFact. Anything else (unknown fields at +0x60..
+  +0x300) inherits from source. If source has a field that
+  encodes "hidden in UI past index N", customs would inherit
+  whatever value the source had. Worth dumping all 0x300 bytes
+  of an OG vs custom track and diffing.
+
+- **Music player UI render cap somewhere distinct from engine.**
+  The Decima UI scroll viewport may have a hardcoded N visible
+  rows. Doesn't explain it being deterministic on track index
+  though.
+
+- **`sub_140c11fa0`-style page selection in UI.** Bucket pages
+  might be category buckets (one per UI tab/album-style
+  grouping). If our customs cluster in just one or two pages
+  and exceed the per-page cap there, only those overflowing
+  pages have hidden tracks. UI shows other pages fine.
+
+Verifying the bucket-overflow theory takes 10 minutes:
+1. Add diagnostic to dump the bucket array post-fill.
+2. Check how many of our custom IDs (0xAD......) are in the
+   bucket array vs the slot table.
+3. If slot table has 142, bucket has < 142 → bucket overflow
+   confirmed. Hook + reimplement bucket lookup.
+
+If bucket has all 142 but UI still hides some → it's something
+else and we need to look at the UI render path (call stack from
+a UI scroll click capture).
+
+##### UI render path identified: `sub_1416e4020`
+
+Found it. The music player menu UI iterates **NOT** the trackArr,
+but the **int32 array** at `data_146230fa8 + 0x1950` (count at
+`+0x1948`):
+
+```c
+sub_1416e4020:
+    int r12 = max(5, *(singleton + 0x1948))   // visible row count
+    for (rdi_1 = 0; rdi_1 < r12; rdi_1++) {
+        // walk playback queue at +0x1940 looking for matching slot
+        while (i != end) {
+            if (i.valid && i.track.id == int32_array[rdi_1]) break
+            i += 0x38
+        }
+        sub_14180b1d0(arg1, ..., i, rdi_1, ...)  // render row
+    }
+```
+
+The int32 array stores TRACK IDs (uint32). The UI shows one row per
+entry. Click-to-play (`sub_14180d6e0`) also uses this array via
+`sub_140c12290` to add new entries.
+
+**The int32 array is populated by walking the bucket array.** When a
+slot makes it into the bucket (via `sub_140c10d90`'s filter), its
+track ID is appended to the int32 array via something like
+`sub_140c12290` (or similar - need to confirm the chain).
+
+So the chain is:
+```
+slot table (+0x4000, 200 entries with our reloc patch)
+   |
+   v   sub_140c10d90 (bucket fill, filtered by album.+0x50 match)
+   |
+bucket array (+0x968, 10 pages × 100, only 35 entries observed)
+   |
+   v   ??? (some function that walks bucket and appends to int32)
+   |
+int32 array (+0x1950, count at +0x1948, dynamic-sized via sub_140c12290)
+   |
+   v   sub_1416e4020 (UI iter)
+   |
+music player menu list (only ~35 visible rows)
+```
+
+**Why bucket fill filters most slots:**
+
+The inner check in `sub_140c10d90` has two gates:
+
+```c
+if (rcx_2 != 0 && (*(rdx_1 + 4) & 1) != 0) {     // back-ptr flag
+    rcx_3 = *(rcx_2 + 0x30);                      // slot.track.album
+    if (rcx_3 != 0 && *(rcx_3 + 0x50) == rsi_1)  // album.+0x50 == outer track
+        ... write bucket entry ...
+}
+```
+
+The check `*(album + 0x50) == outer_track` requires the ALBUM's
+"primary track" reference to match the OUTER LOOP's current track.
+For OG tracks this matches because each album's `+0x50` points to
+its primary track and the album-track linkage is consistent.
+
+For our customs, we keep the source track's ALBUM (don't clone it).
+Album.+0x50 still points to the SOURCE track, not our custom. So
+the outer iteration on our custom: `album.+0x50 (= source) ==
+our_custom` is FALSE. Skip. No bucket entry. Not in int32 array.
+Not in UI list.
+
+The 8 customs that DID make it in: probably borrowed from source
+tracks that were the album's primary, AND those albums got hit
+during outer iteration because outer included OG tracks or somehow
+the linkage worked out. Coincidental match.
+
+##### The fix - hook the int32-array builder
+
+Best path forward: **hook `sub_140c12290` (the int32-array
+appender)** and after the engine's normal population, manually
+append all our custom track IDs to the array.
+
+Approach:
+1. After bucket fill runs (e.g. detected via heartbeat or hooking
+   the right caller), iterate our `g_tracks` vector
+2. For each custom whose ID is NOT already in the int32 array,
+   call `sub_140c12290(singleton, custom_id)` to append it
+3. The UI then iterates the int32 array (now containing all 84
+   customs) and renders all of them
+
+Critical question: does the UI render `sub_14180b1d0` need the
+playback queue (+0x1940) to also have an entry, or does it work
+with the int32 array alone? Looking at the code, it walks the
+queue looking for a matching ID and falls back to `singleton +
+0x27e0` (a default state) on miss. So clicks on tracks not in the
+queue would dispatch via the default path. May or may not play
+correctly - need to test.
+
+If queue entry is required, we additionally need to hook the
+queue builder or reimplement the bucket→int32→queue chain.
+
+##### Sigs collected for next session
+
+- `sub_1416e4020` (UI render): begins with `int32_t arg_8 = 0x6565a4ff`
+  literal followed by `sub_142320530(arg1+0x20, ...)`. Let me confirm
+  the byte sequence with disasm.
+- `sub_140c12290` (int32 array appender): we already xref'd it from
+  `sub_14180d6e0` and `sub_14180d560`. Sig signature TBD.
+- `sub_14180d6e0` (click-to-play handler): the calling convention is
+  `(arg1, arg2)` but I haven't traced what arg2 represents yet -
+  probably the UI element clicked.
+
+##### The bigger picture
+
+Stage 2 (slot-table relocation) is solid at the engine layer. The
+play dispatch works. The remaining problem is purely UI visibility:
+the bucket-fill's album-primary check is the root filter, not a
+size cap. Even if we extended bucket pages to 1000 entries each,
+the album-primary check would still filter out our customs.
+
+Two viable approaches for the next iteration:
+1. **Hook int32-array appender** to bypass bucket fill entirely.
+   Most flexible, doesn't require fighting the album-primary check.
+2. **Make our cloned tracks' albums point back at our custom**
+   instead of inheriting the source's album. That requires cloning
+   the album resource per-custom and patching its +0x50. Larger
+   surface, may have other downstream effects.
+
+Approach 1 wins on cost.
+
+##### Sigs and exact mechanics for the int32-array fix
+
+`sub_140c12290` (int32-array appender, the `g_origAppendInt32`):
+
+```
+prologue:  48 89 5C 24 10 56 48 83 EC 20 48 8B 5A 10 48 8B 35 ?? ?? ?? ?? 48 85 DB 74 ??
+```
+
+API: `void __cdecl(void* arg1_unused, void* arg2_with_track_at_+0x10)`.
+Reads `track = *(arg2 + 0x10)`, then `track_id = *(track + 0x20)`.
+Linearly scans `singleton+0x1950` (count `singleton+0x1948`) for
+matching ID; if not found, calls `sub_1400ae140` to grow the
+vector, appends the ID, increments count, calls `sub_140c12320`
+(playlist resort).
+
+Calling our customs through this is awkward because we need to
+pass a stack-allocated 0x18-byte stub with `[+0x10] = custom_track_ptr`.
+
+`sub_1416e4020` (UI render):
+
+```
+prologue:  48 89 5C 24 10 55 56 57 41 54 41 55 41 56 41 57 48 8D 6C 24 D9 48 81 EC 90 00 00 00 4C 8B F1 C7 45 67 FF A4 65 65
+```
+
+The literal `0xFFA4_6565` is unique enough to make the sig stable.
+
+##### The actual root cause (clearer take)
+
+The bucket-fill outer loop iterates the OG TrackResource array
+(which we extend to 142). For each entry, the inner walks the
+slot table looking for a slot whose `slot.track.album.+0x50 ==
+outer_loop_track`.
+
+For our customs, `slot.track.album` is the source track's album
+(we don't clone albums - all customs borrow). `album.+0x50`
+points to the SOURCE track. So the match condition fires only
+when outer_loop_track == source track. That's a side effect of
+inheritance, not what we want.
+
+Result: when outer iterates OG track 45 ("bb_theme"), all the
+30 customs that borrowed from track 45 match in the inner loop.
+The bucket page for that OG track fills with up to 100 entries
+(1 OG + 30 customs + others). Per-page cap.
+
+When outer iterates OUR custom track, no slot's album.+0x50
+points at our custom. No match. No bucket entry for our customs
+that didn't share an OG outer.
+
+##### Fix strategy: hook `sub_140c109f0` (the engine init wrapper)
+
+Best path: hook the function that calls `sub_140c10c50` (populator)
+and `sub_140c10d90` (bucket fill) in sequence. After bucket fill
+runs, scan the int32 array. For each custom track ID not present,
+manually append.
+
+```cpp
+// sketch:
+static void __cdecl Hook_MusicEngineInit(void* singleton) {
+    g_origMusicEngineInit(singleton);  // runs populator + bucket fill
+
+    if (!g_extendCapEnabled || !g_relocateSlots) return;
+
+    uint8_t* sing = (uint8_t*)singleton;
+    int32_t  count = *(int32_t*)(sing + 0x1948);
+    uint32_t* arr = *(uint32_t**)(sing + 0x1950);
+
+    for (auto& t : g_tracks) {
+        // skip if already present
+        bool found = false;
+        for (int i = 0; i < count; i++) if (arr[i] == t.stableId) { found = true; break; }
+        if (found) continue;
+
+        // append: needs vector grow first. The vector struct is at
+        // +0x1948 (count) / +0x1950 (ptr). sub_1400ae140 grows it.
+        // Easier: just call sub_140c12290 with a fake stub.
+        struct Stub { char pad[0x10]; void* track; };
+        Stub stub = {};
+        stub.track = t.pTrackResource;
+        sub_140c12290(nullptr, &stub);
+    }
+}
+```
+
+We need `g_origMusicEngineInit` resolved (sub_140c109f0). Sig
+should be straightforward - it's the function that calls
+`sub_140c10110` then `sub_140c10c50` then 32× `sub_1400ba3c0`.
+
+`sub_140c109f0` xrefs to `data_146230f88`:
+- `+0x140c10a10` (assignment of singleton ptr)
+- `+0x140c10a69`, `+0x140c10bd6`, `+0x140c10c1c`
+
+Caller of sub_140c109f0 → ?? (need to check).
+
+##### Open questions for next session
+
+1. Will the rendered UI rows for our manually-appended IDs work
+   when clicked? Click-to-play uses `sub_14180d6e0` which pulls
+   queue entries by index. If queue (+0x1940) doesn't have an
+   entry for our custom, click might fall back or fail silently.
+   May need to also populate the queue.
+
+2. Or: hook `sub_14180d6e0` (the click handler) to detect clicks
+   on our custom track IDs and route them through the existing
+   PostEvent path that already plays customs correctly.
+
+3. Album cloning approach (alternative): clone each source's
+   album per-custom and set `cloned_album.+0x50 = custom_track`.
+   Then bucket-fill's natural check passes. Tradeoff: 84 × 0x80
+   = 10.5KB album allocations. May have other downstream filter
+   effects we haven't seen yet.
+
+##### Bottom line
+
+Stage 2 (slot relocation) gives us all 200 slots populated with
+our tracks - that part is solid. The UI cap is purely the
+bucket-fill album-primary filter. Two clean fix routes:
+
+1. **Hook sub_140c109f0**, post-process int32 array to inject
+   missing custom IDs. UI shows them. Click handler may need
+   extra hook to dispatch correctly. ~50 lines.
+
+2. **Clone each custom's album** with proper primary-track-ref.
+   Bucket-fill naturally includes them. Heavier, may have other
+   effects. ~60 lines plus diagnosis of any side effects.
+
+Approach 1 is the cleaner first attempt.
+
+##### Final hookpoint identified: `sub_140c11ee0`
+
+Tracing the music engine init from `sub_141eb9500` (global game
+init), the music engine is set up in this exact sequence at
+`+0x141ebae6e..+0x141ebaeb7`:
+
+```
+1. sub_1400a18a0(0x28c8)             // alloc singleton (we hook this)
+2. sub_140c0fef0(buf)                // ctor (we hook this)
+3. data_146230fa8 = singleton
+4. sub_140c14d70(singleton)          // clear-init regions
+5. sub_140c10300(singleton, sub_140c109f0(singleton))  // some init w/ return value
+6. sub_140c10880(singleton)          // another init
+7. sub_140c10d90(singleton)          // bucket fill (we patched)
+8. sub_140c11ee0(singleton)          // playback queue + int32-array setup
+```
+
+After step 8, `+0x1948/+0x1950` (the int32 array the UI iterates)
+is fully populated with whatever bucket-fill produced. **This is
+the hook target.**
+
+`sub_140c11ee0` body (already decompiled earlier):
+```
+sub_140c11fa0(arg1, *(arg1 + 0x1900), arg1 + 0x1948)  // grows int32 array via dedup-append
+sub_140c12090(arg1, 0)                                 // ?
+sub_140c12120(arg1)                                    // playlist shuffle (+0x1958/+0x1960 array)
+// then iterate +0x1940 playback queue, set flags
+```
+
+**Hook plan:**
+
+```cpp
+typedef void (__cdecl* QueueSetupFn)(void* singleton);
+static QueueSetupFn g_origQueueSetup = nullptr;
+
+static void __cdecl Hook_QueueSetup(void* singleton) {
+    g_origQueueSetup(singleton);  // builds int32 array from bucket entries
+
+    if (!g_relocateSlots) return;
+
+    // Append our custom track IDs to the int32 array if not already present.
+    uint8_t* sing = (uint8_t*)singleton;
+    int32_t*  countPtr = (int32_t*) (sing + 0x1948);
+    uint32_t** arrPtrPtr = (uint32_t**)(sing + 0x1950);
+    int32_t   curCount = *countPtr;
+    uint32_t* arr = *arrPtrPtr;
+
+    for (auto& t : g_tracks) {
+        // dedup: already present?
+        bool found = false;
+        for (int32_t i = 0; i < curCount; i++) {
+            if (arr[i] == t.stableId) { found = true; break; }
+        }
+        if (found) continue;
+
+        // append. easiest path: call sub_140c12290 with a stub that has
+        // our track ptr at +0x10. the function handles vector grow +
+        // count increment + dedup itself.
+        struct Stub { uint8_t pad[0x10]; void* trackPtr; };
+        Stub stub = {};
+        stub.trackPtr = t.pTrackResource;
+        g_appendInt32(nullptr, &stub);
+    }
+
+    // re-read since g_appendInt32 grew the array
+    Log("[MUSICMOD] [extend] queue-setup: int32 array now has %d entries\n",
+        *countPtr);
+}
+```
+
+Sigs needed:
+- `sub_140c11ee0`: prologue. Need to fetch.
+- `sub_140c12290`: prologue (already have above).
+
+##### Open question: does click-to-play work for added entries?
+
+The UI render at `sub_1416e4020` looks up each int32 entry against
+the playback queue (`+0x1940`) by track ID. For our customs whose
+slot ISN'T in the queue (because bucket-fill skipped them), the
+fallback is `singleton + 0x27e0` (a default entry in the tail
+state region).
+
+`sub_14180d6e0` (click handler) uses queue index. If our custom
+ends up routed through the fallback default, click might dispatch
+the default entry's track instead of our custom.
+
+If clicks fail, the additional fix is: also populate the playback
+queue (`+0x1940`) with our customs. Each entry is 0x38 bytes:
+- `+0x10`: track resource pointer
+- `+0x35`: valid byte (0 = valid for matching)
+- other fields probably needed too
+
+Would need to disasm `sub_140c10d90`'s bucket-write logic and
+mirror it.
+
+Or simpler: hook `sub_14180d6e0` to detect clicks on our custom
+track IDs and dispatch via the existing PostEvent path that
+already plays customs correctly.
+
+##### Implementation that landed
+
+Two changes to `Hook_SlotPopulator` and one new hook on `sub_140c11ee0`:
+
+1. **Extended first-table at `singleton+0x5400`.** The album-primary
+   filter at `sub_140c10d90+0x113` reads `(slot+0x10).+4 & 1`. Slots
+   100..199 used to have `slot+0x10 = nullptr` so the filter failed,
+   keeping customs out of the playback queue. The slot populator now
+   writes a parallel first-table at `+0x5400` (100*24 bytes, 0x140
+   margin from slot-table end at 0x52C0, 0x2A0 margin to buffer end
+   at 0x6000). Each entry gets `trackId` at `+0` and music-capable
+   bit at `+4`, mirroring what the original populator does for slots
+   0..99.
+
+2. **`Hook_QueueSetup` on `sub_140c11ee0`.** After the original runs
+   (which calls `sub_140c11fa0` to populate the int32 array at
+   `+0x1948`/`+0x1950` from one bucket page filtered by playback-
+   queue match), iterate `g_tracks`, and for each `stableId` not
+   already in the array, call `sub_1400ae140(sing+0x1948, count+1)`
+   to grow it, write the ID at `[count]`, then increment count. This
+   is the same call sequence the engine itself uses inside
+   `sub_140c11fa0`. The UI iterator at `sub_1416e4020` reads
+   `count = *(sing+0x1948)`, walks `*(sing+0x1950)`, and for each
+   entry walks the playback queue at `+0x1940` to find a matching
+   `(queue.+0x10).+0x20 == id` to render the row.
+
+Two new sigs:
+- `sub_140c11ee0`: prologue + `mov edx, [rcx+0x1900]; lea r8, [rcx+0x1948]; mov rbx, rcx`
+- `sub_1400ae140`: prologue + `mov r14d, edx; mov rbp, [rcx+8]; mov rsi, rcx; cmp edx, [rcx+4]`
+
+Both gated behind `.relocate_slots` so Stage 1 (cap-fix-only) is
+unaffected. If clicks on customs past index 42 don't play correctly
+even with the row visible, the next thing to check is
+`sub_14180d6e0` (click handler) - we may need to redirect to
+PostEvent there too.
 
 ## 4. Album art binding (the part I didn't finish)
 

--- a/src/ds2_musicplayer.cpp
+++ b/src/ds2_musicplayer.cpp
@@ -54,8 +54,15 @@ static volatile bool g_shuttingDown = false;
 static LARGE_INTEGER g_perfFreq = {};
 static LARGE_INTEGER g_perfStart = {};
 
+// Verbose diagnostic logging toggle (sd_music/.debug_log flag file).
+// Set during init based on the flag file's presence. Used by LogDebug.
+static bool g_debugLog = false;
+
 // SEH body extracted into its own function so we can use __try without
 // running into C2712 (lock_guard requires C++ unwinding in the caller).
+// fflush is NOT called here: a background flusher thread (FlushWorker)
+// pumps it every ~250ms so audio-thread Log calls don't block on disk
+// I/O. Crash dumps still force-flush via fflush(g_log) at the call site.
 static void LogImplSEH(const char* fmt, va_list args) {
     __try {
         LARGE_INTEGER now;
@@ -63,13 +70,28 @@ static void LogImplSEH(const char* fmt, va_list args) {
         double elapsed = (double)(now.QuadPart - g_perfStart.QuadPart) / g_perfFreq.QuadPart;
         fprintf(g_log, "[%7.2fs] ", elapsed);
         vfprintf(g_log, fmt, args);
-        fflush(g_log);
     } __except(EXCEPTION_EXECUTE_HANDLER) {
-        if (g_log) { fputs("[%LOG FAULT - swallowed]\n", g_log); fflush(g_log); }
+        if (g_log) { fputs("[%LOG FAULT - swallowed]\n", g_log); }
     }
 }
 
 static void Log(const char* fmt, ...) {
+    if (!g_log || g_shuttingDown) return;
+    std::lock_guard<std::mutex> lock(g_logMtx);
+    if (g_shuttingDown) return;
+    va_list args;
+    va_start(args, fmt);
+    LogImplSEH(fmt, args);
+    va_end(args);
+}
+
+// Debug-only verbose logging. No-op unless sd_music/.debug_log flag exists.
+// Used for high-volume diagnostic streams (PostEvent, dtor-router, SetMedia,
+// per-track tag reads) that flood the log during normal gameplay and stall
+// the audio thread when fflush'd inline. Release-shaped runs default to
+// quiet; debug runs (flag file present) get full diagnostic output.
+static void LogDebug(const char* fmt, ...) {
+    if (!g_debugLog) return;
     if (!g_log || g_shuttingDown) return;
     std::lock_guard<std::mutex> lock(g_logMtx);
     if (g_shuttingDown) return;
@@ -423,6 +445,67 @@ static void DumpMusicEngineSingleton(const char* tag);
 // to call from any thread.
 static void MaybeDumpSingleton(const char* tag);
 
+// Cap extension: hook the music engine ctor to allocate a larger buffer
+// and patch the 100-cap immediates / table-end markers to widen the slot
+// table. Gated behind sd_music/.extend_cap so default behavior is unchanged
+// until proven safe.
+typedef void* (__cdecl* MusicCtorFn)(void* arg1);
+typedef void* (__cdecl* DecimaAllocFn)(size_t sz);
+typedef void  (__cdecl* MusicBucketFillFn)(void* singleton);
+typedef int64_t (__cdecl* DestructorRouterFn)(void* arg1, uint8_t arg2);  // sub_1400ba3c0
+typedef void  (__cdecl* SlotPopulatorFn)(void* singleton);                // sub_140c10c50
+typedef int64_t (__cdecl* SaveMusicFn)(void* arg1, void* arg2, uint8_t arg3); // sub_140714000
+typedef void  (__cdecl* QueueSetupFn)(void* singleton);                   // sub_140c11ee0
+typedef void* (__cdecl* ArrayGrowFn)(void* arrStruct, int32_t newCount);  // sub_1400ae140
+static MusicCtorFn       g_origMusicCtor    = nullptr;
+static MusicBucketFillFn g_origBucketFill   = nullptr;
+static DecimaAllocFn     g_decimaAlloc      = nullptr;  // sub_1400a18a0 (jemalloc-backed)
+static DestructorRouterFn g_origDtorRouter  = nullptr;  // sub_1400ba3c0
+static SlotPopulatorFn   g_origSlotPopulator = nullptr; // sub_140c10c50
+static SaveMusicFn       g_origSaveMusic     = nullptr; // sub_140714000
+static QueueSetupFn      g_origQueueSetup    = nullptr; // sub_140c11ee0
+static ArrayGrowFn       g_arrayGrow         = nullptr; // sub_1400ae140
+static uintptr_t   g_musicCtorAddr = 0;
+static uintptr_t   g_musicWalkAddr = 0;  // sub_140c11d50
+static uintptr_t   g_musicBucketAddr = 0;  // sub_140c10d90
+static uintptr_t   g_dtorRouterAddr = 0;   // sub_1400ba3c0
+static uintptr_t   g_slotPopulatorAddr = 0; // sub_140c10c50
+static uintptr_t   g_loadGameAddr = 0;     // sub_140c15080
+static uintptr_t   g_saveMusicAddr = 0;    // sub_140714000
+static uintptr_t   g_queueSetupAddr = 0;   // sub_140c11ee0
+static uintptr_t   g_arrayGrowAddr  = 0;   // sub_1400ae140
+static void**      g_sysResGlobal = nullptr; // -> data_146230f88 (DSMusicPlayerSystemResource ptr)
+static bool        g_extendCapEnabled = false;
+static bool        g_extendCtorRan    = false;  // set by Hook_MusicCtor
+static bool        g_relocateSlots    = false;  // sd_music/.relocate_slots
+constexpr uint32_t kSlotTableOldOff   = 0x1970;   // baked-in slot table offset
+constexpr uint32_t kSlotTableNewOff   = 0x4000;   // relocated to slack
+constexpr uint32_t kSlotTableOldSize  = 0x960;    // 100 * 24
+constexpr uint32_t kSlotTableNewSize  = 0x12C0;   // 200 * 24
+// Extended first-table region for slots 100..199. Original first-table is
+// at offsets 0..0x960 (100 * 24); we keep that intact for save-blob compat.
+// The extension lives in slack at +0x5400 (0x140 past slot-table end at
+// 0x52C0, with 0x2A0 margin to the buffer end at 0x6000).
+constexpr uint32_t kFirstTableExtOff  = 0x5400;
+constexpr uint32_t kFirstTableExtSize = 0x960;    // 100 * 24
+constexpr uint32_t kOldCap            = 100;
+constexpr uint32_t kNewCap            = 200;
+static void* __cdecl Hook_MusicCtor(void* origBuf);
+static void  __cdecl Hook_BucketFill_SwallowCrash(void* singleton);
+static int64_t __cdecl Hook_DtorRouter(void* arg1, uint8_t arg2);
+static void  __cdecl Hook_SlotPopulator(void* singleton);
+static int64_t __cdecl Hook_SaveMusic(void* arg1, void* arg2, uint8_t arg3);
+static void  __cdecl Hook_QueueSetup(void* singleton);
+static bool PatchByte(void* addr, uint8_t newByte, const char* what);
+static bool PatchU32(void* addr, uint32_t newVal, const char* what);
+// Relocate the slot table from its baked-in offset +0x1970 to +0x4000
+// (in the slack region of our 0x6000 buffer). 200 entries x 24 bytes = 0x12C0
+// total span, ending at +0x52C0, well before the buffer end at +0x6000.
+constexpr uint32_t SLOT_TABLE_NEW_OFFSET = 0x4000;
+constexpr uint32_t SLOT_TABLE_NEW_SIZE   = 0x12C0;  // 200 * 24
+constexpr uint8_t  EXTENDED_CAP_BYTE     = 0xC8;     // 200 (replaces 0x64=100 walks)
+constexpr uint8_t  EXTENDED_CAP_BYTE_DEC = 0xC7;     // 199 (replaces 0x63=99 cmps)
+
 // PostEvent forward decl
 typedef uint32_t (__cdecl* PostEventByIdFn)(
     uint32_t eventId, uint64_t gameObjId, uint32_t flags,
@@ -705,6 +788,77 @@ static void ScanMusicFolder() {
               [](const CustomTrack& a, const CustomTrack& b) {
                   return a.stableId < b.stableId;
               });
+
+    // playlist.txt support - lets users with libraries larger than the
+    // music engine's hardcoded 100-track cap (= 42 customs after the 58
+    // OG tracks) pick which custom tracks load this session. Each non-
+    // empty, non-comment line in sd_music/playlist.txt is a basename of a
+    // file that should be loaded (in playlist order, before anything not
+    // listed). Files in sd_music/ that aren't in the playlist still load
+    // if there's room. Comments are lines starting with #.
+    char playlistPath[MAX_PATH];
+    snprintf(playlistPath, MAX_PATH, "%s\\sd_music\\playlist.txt", g_gameDir);
+    FILE* pf = fopen(playlistPath, "rb");
+    if (pf) {
+        std::vector<std::string> wantOrder;
+        char line[1024];
+        while (fgets(line, sizeof(line), pf)) {
+            // strip CR/LF and trailing whitespace
+            size_t n = strlen(line);
+            while (n && (line[n-1] == '\n' || line[n-1] == '\r' ||
+                          line[n-1] == ' ' || line[n-1] == '\t'))
+                line[--n] = 0;
+            // skip leading whitespace
+            char* p = line;
+            while (*p == ' ' || *p == '\t') p++;
+            if (!*p || *p == '#') continue;
+            wantOrder.emplace_back(p);
+        }
+        fclose(pf);
+        Log("[MUSICMOD] playlist.txt: %zu entries\n", wantOrder.size());
+
+        // Reorder g_tracks: first the entries that match playlist names
+        // (in playlist order), then everything else (preserving stableId
+        // order for the rest). Match is case-insensitive on the basename
+        // (Windows filesystems are case-insensitive so users typing the
+        // wrong case shouldn't get silently dropped).
+        auto basenameOf = [](const std::string& path) -> std::string {
+            size_t s = path.find_last_of("\\/");
+            return (s == std::string::npos) ? path : path.substr(s + 1);
+        };
+        auto eqCI = [](const std::string& a, const std::string& b) {
+            if (a.size() != b.size()) return false;
+            for (size_t i = 0; i < a.size(); i++) {
+                if (tolower((unsigned char)a[i]) != tolower((unsigned char)b[i]))
+                    return false;
+            }
+            return true;
+        };
+        std::vector<CustomTrack> ordered;
+        ordered.reserve(g_tracks.size());
+        std::vector<bool> taken(g_tracks.size(), false);
+        for (auto& want : wantOrder) {
+            bool found = false;
+            for (size_t i = 0; i < g_tracks.size(); i++) {
+                if (taken[i]) continue;
+                if (eqCI(basenameOf(g_tracks[i].filepath), want)) {
+                    ordered.push_back(std::move(g_tracks[i]));
+                    taken[i] = true;
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                Log("[MUSICMOD] playlist.txt: \"%s\" not found in sd_music/\n",
+                    want.c_str());
+            }
+        }
+        // append leftovers in their existing (stableId) order
+        for (size_t i = 0; i < g_tracks.size(); i++) {
+            if (!taken[i]) ordered.push_back(std::move(g_tracks[i]));
+        }
+        g_tracks = std::move(ordered);
+    }
 
     Log("[MUSICMOD] found %zu audio file(s)\n", g_tracks.size());
 }
@@ -2150,12 +2304,14 @@ static void InjectCustomTracks(void* sysRes) {
     // with just the OG tracks loaded, gives us a baseline to diff against.
     DumpMusicEngineSingleton("InjectCustomTracks PRE");
 
-    // The Wwise music engine has a hardcoded 100-track cap. The engine
-    // singleton (allocated as 10440 bytes via sub_1400a18a0(0x28c8) inside
-    // sub_141eb9500, address stored in data_146230fa8, constructor
-    // sub_140c0fef0) contains three fixed-size 100-cap arrays and one 32-cap
-    // array, all at baked-in offsets. The 100-cap is enforced via 0x64
-    // immediates in sub_140c11d50, sub_140c10d90, and sub_140c12320.
+    // The Wwise music engine has a hardcoded 100-track cap (or 200 when the
+    // experimental .extend_cap flag is active and our patches widened the
+    // slot table - see Hook_MusicCtor). The engine singleton (allocated as
+    // 10440 bytes via sub_1400a18a0(0x28c8) inside sub_141eb9500, address
+    // stored in data_146230fa8, constructor sub_140c0fef0) contains three
+    // fixed-size 100-cap arrays and one 32-cap array, all at baked-in
+    // offsets. The 100-cap is enforced via 0x64 immediates in
+    // sub_140c11d50, sub_140c10d90, and sub_140c12320.
     //
     // Singleton struct layout (mapped from sub_140c0fef0):
     //   +0x000..+0x960 : 100-entry x 24B table (fields init 0/0/0x4b/0x4b/...)
@@ -2173,22 +2329,36 @@ static void InjectCustomTracks(void* sysRes) {
     // all three arrays relocated to trailing slack in an enlarged singleton
     // alloc, plus every LEA that computes a table base patched, plus all
     // 0x64/0x63 immediates patched. Multi-day project, not done here.
-    constexpr uint32_t MUSIC_ENGINE_TRACK_CAP = 100;
+    // Cap stays at 100 by default - the LEA-relocation extension attempt
+    // was rolled back after multiple failed attempts (see Hook_MusicCtor
+    // and RESEARCH.md for the dead-end analysis).
+    //
+    // With sd_music/.extend_cap, the upstream cap bumps to 200 AND the
+    // ctor hook hands the engine a 0x6000 buffer (instead of 0x28c8)
+    // so writes past +0x28c8 don't fall off the end. No LEA patches
+    // run - this is the isolation test: does the engine actually
+    // enforce a 100 cap by itself, or were earlier crashes purely
+    // from the LEA patches stomping pointer arithmetic? Slot 100..199
+    // writes land in the original transition-history / tail-state
+    // region (+0x22D0..+0x2D78), so corruption of those regions is
+    // expected if the engine touches them - that's the signal we want.
+    const uint32_t MUSIC_ENGINE_TRACK_CAP = g_extendCapEnabled ? 200u : 100u;
     if ((uint32_t)g_tracks.size() + trackArr->count > MUSIC_ENGINE_TRACK_CAP) {
         uint32_t allowed = (trackArr->count >= MUSIC_ENGINE_TRACK_CAP)
                              ? 0u
                              : (MUSIC_ENGINE_TRACK_CAP - trackArr->count);
         Log("[MUSICMOD] *** TRACK LIMIT HIT ***\n");
-        Log("[MUSICMOD] *** You have %zu custom tracks but the game's music\n",
+        Log("[MUSICMOD] *** You have %zu custom tracks but the music engine\n",
             g_tracks.size());
-        Log("[MUSICMOD] *** engine has a hardcoded 100-track total cap\n");
+        Log("[MUSICMOD] *** is capped at %u total tracks right now\n",
+            MUSIC_ENGINE_TRACK_CAP);
         Log("[MUSICMOD] *** (%u OG tracks + %zu custom = %zu, max is %u).\n",
             trackArr->count, g_tracks.size(),
             g_tracks.size() + trackArr->count, MUSIC_ENGINE_TRACK_CAP);
         Log("[MUSICMOD] *** Dropping %zu of your tracks to fit. Move files\n",
             g_tracks.size() - allowed);
         Log("[MUSICMOD] *** out of sd_music/ to control which ones load.\n");
-        Log("[MUSICMOD] *** Pushing past 100 needs music engine relocation\n");
+        Log("[MUSICMOD] *** Pushing past the cap needs music engine relocation\n");
         Log("[MUSICMOD] *** work that's still in progress - see RESEARCH.md.\n");
         g_tracks.resize(allowed);
         if (g_tracks.empty()) {
@@ -4333,11 +4503,19 @@ static uint32_t __cdecl Hook_PostEvent(
         eventId = CUSTOM_EVENT_BASE + idx;
         Log("[MUSICMOD] *** SUBST: event %u -> %u (custom track %u, gameObj=%llu)\n",
             origEvent, eventId, idx, (unsigned long long)gameObjId);
-    } else {
+    } else if (isMusic || customLabel) {
+        // Music events and our custom events: always log (low frequency,
+        // diagnostic signal we always want to see).
         Log("[MUSICMOD] PE id=%u (0x%08X)%s%s obj=%llu fl=0x%X cb=%p pid=%u\n",
             eventId, eventId,
             customLabel ? " " : "",
             customLabel ? customLabel : "",
+            (unsigned long long)gameObjId, flags, callback, playingId);
+    } else if (g_debugLog) {
+        // Gameplay PostEvents only logged in debug mode. Hundreds per
+        // second during combat, would stall audio thread otherwise.
+        LogDebug("[MUSICMOD] PE id=%u (0x%08X) obj=%llu fl=0x%X cb=%p pid=%u\n",
+            eventId, eventId,
             (unsigned long long)gameObjId, flags, callback, playingId);
         // for custom events, capture call stack so we can find the game
         // function that drives our music-player play path
@@ -4387,8 +4565,13 @@ static uint32_t __cdecl Hook_PostEvent(
         g_lastCustomPositionMs = 0;
     }
 
-    Log("[MUSICMOD]   -> playingId=%u%s%s\n",
-        result, isMusic ? " (music)" : "", (result == 0) ? " REJECTED" : "");
+    if (isMusic || customLabel) {
+        Log("[MUSICMOD]   -> playingId=%u%s%s\n",
+            result, isMusic ? " (music)" : "", (result == 0) ? " REJECTED" : "");
+    } else if (g_debugLog) {
+        LogDebug("[MUSICMOD]   -> playingId=%u%s\n",
+            result, (result == 0) ? " REJECTED" : "");
+    }
 
     return result;
 }
@@ -4746,6 +4929,182 @@ static void ResolveGameAddresses() {
     } else {
         Log("[MUSICMOD] music engine singleton sig NOT FOUND\n");
     }
+
+    // Cap-extension hook target sig scans. Both sigs are uniquely anchored
+    // on the function prologue + first few instructions.
+    g_musicCtorAddr = PatternScan(textStart, textSize,
+        "48 89 5C 24 08 48 89 74 24 10 57 48 83 EC 20 48 8B D9 BF 64 00 00 00 8B CF 33 F6 48 8D 43 08");
+    Log("[MUSICMOD] [extend] sub_140c0fef0 (music ctor) -> %p\n", (void*)g_musicCtorAddr);
+
+    g_musicWalkAddr = PatternScan(textStart, textSize,
+        "48 89 5C 24 08 48 89 6C 24 10 48 89 74 24 18 48 89 7C 24 20 41 56 48 83 EC 20 48 8B E9 48 8D B9 78 19 00 00 BE 64 00 00 00");
+    Log("[MUSICMOD] [extend] sub_140c11d50 (music walk) -> %p\n", (void*)g_musicWalkAddr);
+
+    // sub_140c10d90 - bucket/slot fill, called from the music engine init
+    // sequence and crashed earlier when its slot-table walks disagreed with
+    // patched walks elsewhere. Sig: prologue + cmp [rel data_146230f88], r14
+    g_musicBucketAddr = PatternScan(textStart, textSize,
+        "48 8B C4 48 89 48 08 55 41 56 41 57 48 8D 68 A1 48 81 EC 00 01 00 00 45 33 FF 45 8B F7 44 89 7D 7F 4C 39 35");
+    Log("[MUSICMOD] [extend] sub_140c10d90 (bucket fill) -> %p\n", (void*)g_musicBucketAddr);
+
+    // sub_1400a18a0 - the game's jemalloc-backed allocator. Single arg
+    // (size), returns void*. Critical for the cap-extension hook because
+    // VirtualAlloc'd buffers crash later when jemalloc tries to look up
+    // their chunk metadata.
+    uintptr_t decimaAllocAddr = PatternScan(textStart, textSize,
+        "48 89 5C 24 08 57 48 83 EC 20 65 48 8B 04 25 58 00 00 00 48 8B F9 48 8B 18");
+    g_decimaAlloc = (DecimaAllocFn)decimaAllocAddr;
+    Log("[MUSICMOD] [extend] sub_1400a18a0 (game allocator) -> %p\n", (void*)g_decimaAlloc);
+
+    // sub_1400ba3c0 - generic destructor router. Reads *(arg1+8) as an
+    // object pointer, looks up its allocator, vcalls destructor at +0x90.
+    // Crashes when bucket-fill walks slots whose +8 field contains one
+    // of our 0xAD8..... custom track IDs (treated as object ptr -> AV).
+    // Sig: 40 53 48 83 EC 20 48 8B D9 84 D2 75 ?? 48 8B 51 08 48 85 D2 74 ??
+    g_dtorRouterAddr = PatternScan(textStart, textSize,
+        "40 53 48 83 EC 20 48 8B D9 84 D2 75 ?? 48 8B 51 08 48 85 D2 74 ?? 48 3B 15");
+    Log("[MUSICMOD] [extend] sub_1400ba3c0 (destructor router) -> %p\n", (void*)g_dtorRouterAddr);
+
+    // sub_140c10c50 - the slot table populator. Walks the OG TrackResource
+    // array (DSMusicPlayerSystemResource +0x30 count, +0x38 ptr) and writes
+    // one 24B slot entry per track into the slot table at +0x1970, with
+    // NO destination cap. Hook lets us clamp the source count to 100 around
+    // the call so the populator can't spill into the transition history at
+    // +0x22D0 or the bucket array at +0x968 (via the coupled first-table
+    // writes at +0x000+i*24).
+    // Sig: prologue + the rdi=arg1+0x1998 init + count-of-10 loop entry.
+    g_slotPopulatorAddr = PatternScan(textStart, textSize,
+        "4C 8B 05 ?? ?? ?? ?? 4D 85 C0 0F 84 ?? ?? ?? ?? 48 8D 81 98 19 00 00 BA 0A 00 00 00");
+    Log("[MUSICMOD] [extend] sub_140c10c50 (slot populator) -> %p\n", (void*)g_slotPopulatorAddr);
+
+    // sub_140c15080 - load-game deserializer. Reads saved 0x1910-byte blob,
+    // rebuilds slot back-pointers via unrolled per-page recovery loops.
+    // Used by stage 2 (relocation) to redirect those writes to +0x4000.
+    // Sig: prologue (push rbp; push rbx; push rsi; push r14) + chkstk-1968.
+    g_loadGameAddr = PatternScan(textStart, textSize,
+        "40 55 53 56 41 56 48 8D AC 24 98 E7 FF FF B8 68 19 00 00 E8 ?? ?? ?? ?? 48 2B E0 48 8B 05");
+    Log("[MUSICMOD] [extend] sub_140c15080 (load game) -> %p\n", (void*)g_loadGameAddr);
+
+    // sub_140714000 - music-state save serializer. Hooked by extend_cap
+    // (any stage) to scrub custom IDs from the bucket array around the
+    // save call so vanilla can read the save without our 0xAD..... IDs.
+    // Sig: prologue + the 0x474d4e42 ('GMNB') chunk-tag mov.
+    g_saveMusicAddr = PatternScan(textStart, textSize,
+        "48 89 5C 24 08 48 89 74 24 20 55 57 41 54 41 56 41 57 48 8B EC 48 81 EC 80 00 00 00");
+    Log("[MUSICMOD] [extend] sub_140714000 (save music) -> %p\n", (void*)g_saveMusicAddr);
+
+    // sub_140c11ee0 - queue-setup, called at the end of music-engine init
+    // after sub_140c10d90 (bucket fill). Calls sub_140c11fa0 which builds
+    // the int32 array at singleton+0x1948/+0x1950 (the array the music-
+    // player UI iterates to render rows). Hooked so we can append custom
+    // track IDs that the engine's bucket-driven population missed.
+    // Sig: prologue + `mov edx, [rcx+0x1900]; lea r8, [rcx+0x1948]; mov rbx, rcx`.
+    g_queueSetupAddr = PatternScan(textStart, textSize,
+        "48 89 5C 24 08 57 48 83 EC 20 8B 91 00 19 00 00 4C 8D 81 48 19 00 00 48 8B D9 E8");
+    Log("[MUSICMOD] [extend] sub_140c11ee0 (queue setup) -> %p\n", (void*)g_queueSetupAddr);
+
+    // sub_1400ae140 - generic Decima Array<T> grow. Takes (struct, newCount);
+    // struct layout is { int32 count; int32 cap; void* ptr }. If newCount
+    // > cap, reallocates ptr via game allocator. Returns ptr.
+    // Sig: prologue + `mov r14d, edx; mov rbp, [rcx+8]; mov rsi, rcx; cmp edx, [rcx+4]`.
+    g_arrayGrowAddr = PatternScan(textStart, textSize,
+        "40 55 56 41 56 48 83 EC 30 44 8B F2 48 8B 69 08 48 8B F1 3B 51 04");
+    g_arrayGrow = (ArrayGrowFn)g_arrayGrowAddr;
+    Log("[MUSICMOD] [extend] sub_1400ae140 (array grow) -> %p\n", (void*)g_arrayGrowAddr);
+
+    // The first 7 bytes of the populator are `mov r8, qword [rel ...]`
+    // loading the DSMusicPlayerSystemResource pointer (data_146230f88).
+    // Resolve the RIP-relative target so we can read/write its trackArr
+    // count from our hook.
+    if (g_slotPopulatorAddr) {
+        g_sysResGlobal = (void**)RipRelTarget(g_slotPopulatorAddr, 7, 3);
+        Log("[MUSICMOD] [extend] DSMusicPlayerSystemResource ptr global @ %p\n", (void*)g_sysResGlobal);
+    }
+
+    // Check for the verbose-logging flag. Default off so production runs
+    // get only crashes, errors, and one-shot init/state messages. Setting
+    // sd_music/.debug_log enables LogDebug() calls (PostEvent spam,
+    // dtor-router pass-through, SetMedia enumeration, per-track tag reads,
+    // etc.) for diagnosis.
+    {
+        char debugFlag[MAX_PATH];
+        snprintf(debugFlag, MAX_PATH, "%s\\sd_music\\.debug_log", g_gameDir);
+        if (GetFileAttributesA(debugFlag) != INVALID_FILE_ATTRIBUTES) {
+            g_debugLog = true;
+            Log("[MUSICMOD] verbose logging ENABLED (sd_music/.debug_log present)\n");
+        }
+    }
+
+    // Music engine cap extension. Grows the engine singleton from 0x28C8
+    // to 0x6000, relocates the slot table from +0x1970 to +0x4000 (cap
+    // 200), parks an extended first-table at +0x5400, and patches every
+    // reader function that touches those offsets. Disabled cleanly if any
+    // of the required sigs miss.
+    if (!(g_musicCtorAddr && g_musicWalkAddr && g_decimaAlloc)) {
+        Log("[MUSICMOD] [extend] core sigs missing (ctor=%p walk=%p alloc=%p) - cap extension disabled\n",
+            (void*)g_musicCtorAddr, (void*)g_musicWalkAddr, (void*)g_decimaAlloc);
+        return;
+    }
+
+    g_origMusicCtor = (MusicCtorFn)InstallHookMH(
+        (void*)g_musicCtorAddr, (void*)Hook_MusicCtor, "MusicCtor");
+    if (!g_origMusicCtor) {
+        Log("[MUSICMOD] [extend] ctor hook install FAILED - cap extension disabled\n");
+        return;
+    }
+    g_extendCapEnabled = true;
+    g_relocateSlots    = true;
+
+    // Destructor-router shim. Without it, the engine AVs in sub_1400ba3c0
+    // when bucket-fill walks past slot 99 with custom IDs in the +8 field.
+    if (g_dtorRouterAddr) {
+        g_origDtorRouter = (DestructorRouterFn)InstallHookMH(
+            (void*)g_dtorRouterAddr, (void*)Hook_DtorRouter, "DtorRouter");
+        Log("[MUSICMOD] [extend] dtor-router shim %s\n",
+            g_origDtorRouter ? "installed" : "install FAILED");
+    } else {
+        Log("[MUSICMOD] [extend] dtor-router sig MISS\n");
+    }
+
+    // Slot populator. Reimplements sub_140c10c50 to write 200 slots into
+    // the relocated table without spilling into adjacent regions.
+    if (g_slotPopulatorAddr && g_sysResGlobal) {
+        g_origSlotPopulator = (SlotPopulatorFn)InstallHookMH(
+            (void*)g_slotPopulatorAddr, (void*)Hook_SlotPopulator, "SlotPopulator");
+        Log("[MUSICMOD] [extend] slot-populator hook %s\n",
+            g_origSlotPopulator ? "installed" : "install FAILED");
+    } else {
+        Log("[MUSICMOD] [extend] slot-populator sig MISS or sysRes global unresolved\n");
+    }
+
+    // Save scrubber. Strips 0xAD..... custom IDs from the bucket array
+    // around the save call so the saved blob stays vanilla-readable when
+    // the mod is removed. Live state restored after the call returns.
+    if (g_saveMusicAddr) {
+        g_origSaveMusic = (SaveMusicFn)InstallHookMH(
+            (void*)g_saveMusicAddr, (void*)Hook_SaveMusic, "SaveMusic");
+        Log("[MUSICMOD] [extend] save-music hook %s\n",
+            g_origSaveMusic ? "installed" : "install FAILED");
+    } else {
+        Log("[MUSICMOD] [extend] save-music sig MISS\n");
+    }
+
+    // Queue-setup hook. Appends custom IDs to the int32 array at +0x1948
+    // that the music-player UI iterates - customs whose bucket-page
+    // entry got filtered by the album-primary check would otherwise be
+    // invisible even though they're in the playback queue.
+    if (g_queueSetupAddr && g_arrayGrow && g_musicEngineGlobal) {
+        g_origQueueSetup = (QueueSetupFn)InstallHookMH(
+            (void*)g_queueSetupAddr, (void*)Hook_QueueSetup, "QueueSetup");
+        Log("[MUSICMOD] [extend] queue-setup hook %s\n",
+            g_origQueueSetup ? "installed" : "install FAILED");
+    } else {
+        Log("[MUSICMOD] [extend] queue-setup sigs missing (queueSetup=%p arrayGrow=%p engine=%p)\n",
+            (void*)g_queueSetupAddr, (void*)g_arrayGrow, (void*)g_musicEngineGlobal);
+    }
+
+    Log("[MUSICMOD] [extend] cap extension active (200-track ceiling, slot table at +0x%X)\n",
+        kSlotTableNewOff);
 }
 
 // Polled by hot-path hooks to dump the singleton the first time it's
@@ -4771,6 +5130,580 @@ static void MaybeDumpSingleton(const char* tag) {
         DumpMusicEngineSingleton(buf);
         s_lastDumpTick = now;
     }
+}
+
+// Cap extension: small VirtualProtect-wrapped byte/u32 patcher.
+static bool PatchByte(void* addr, uint8_t newByte, const char* what) {
+    DWORD oldProt = 0;
+    if (!VirtualProtect(addr, 1, PAGE_EXECUTE_READWRITE, &oldProt)) {
+        Log("[MUSICMOD] [extend] VirtualProtect failed for %s @ %p: %lu\n",
+            what, addr, GetLastError());
+        return false;
+    }
+    uint8_t orig = *(uint8_t*)addr;
+    *(uint8_t*)addr = newByte;
+    DWORD tmp = 0;
+    VirtualProtect(addr, 1, oldProt, &tmp);
+    FlushInstructionCache(GetCurrentProcess(), addr, 1);
+    Log("[MUSICMOD] [extend] patched %s @ %p: 0x%02X -> 0x%02X\n",
+        what, addr, orig, newByte);
+    return true;
+}
+
+static bool PatchU32(void* addr, uint32_t newVal, const char* what) {
+    DWORD oldProt = 0;
+    if (!VirtualProtect(addr, 4, PAGE_EXECUTE_READWRITE, &oldProt)) {
+        Log("[MUSICMOD] [extend] VirtualProtect failed for %s @ %p: %lu\n",
+            what, addr, GetLastError());
+        return false;
+    }
+    uint32_t orig = *(uint32_t*)addr;
+    *(uint32_t*)addr = newVal;
+    DWORD tmp = 0;
+    VirtualProtect(addr, 4, oldProt, &tmp);
+    FlushInstructionCache(GetCurrentProcess(), addr, 4);
+    Log("[MUSICMOD] [extend] patched %s @ %p: 0x%08X -> 0x%08X\n",
+        what, addr, orig, newVal);
+    return true;
+}
+
+// SEH wrapper around sub_140c10d90 (bucket fill). With LEA-relocation
+// patches active, the original function crashes deep in jemalloc free
+// path because of the implicit-pointer-arithmetic problem. SEH catches
+// the AV so the engine survives - we know it's running with partially-
+// initialized bucket state, but at least we get to see what happens
+// downstream instead of the process dying immediately.
+//
+// This is exploratory - intentionally not a real fix. The crash means
+// some bucket entries didn't get populated, so music routing for those
+// would be broken. Goal: see if the engine still runs at all and what
+// downstream behavior tells us.
+static void __cdecl Hook_BucketFill_SwallowCrash(void* singleton) {
+    if (!g_origBucketFill) return;
+    __try {
+        g_origBucketFill(singleton);
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        Log("[MUSICMOD] [extend] swallowed crash in sub_140c10d90 (bucket fill)\n");
+        Log("[MUSICMOD] [extend] engine state will be partially initialized\n");
+    }
+}
+
+// sub_1400ba3c0 - generic destructor router. Layout:
+//   if (arg2 != 0) { *arg1 = 0; return 0; }   // shortcut path
+//   void* p = *(arg1 + 8);
+//   if (p == 0) { arg1[0] = arg1[1] = 0; return 0; }   // null path
+//   ...look up allocator, vcall destructor at vtable+0x90, then zero...
+//
+// Crash: when extend_cap is on and the bucket-fill walks into upper-region
+// slots whose +8 field happens to contain one of OUR custom track IDs
+// (0xAD8.....), the function casts that ID to an object pointer, reads
+// its vtable, and AVs at 0xAD800060 (or similar). The IDs leak into
+// adjacent memory because the engine's bucket array is laid out next to
+// the slot table and our custom-ID writes spill across the boundary.
+//
+// Shim: detect 0xAD8..... in the +8 field. If seen, take the same
+// short-circuit the function already takes for the null case - zero
+// the slot and return 0. No vcall, no AV. Real game pointers pass
+// through to the original.
+static int64_t __cdecl Hook_DtorRouter(void* arg1, uint8_t arg2) {
+    if (g_extendCapEnabled && arg1 && arg2 == 0) {
+        __try {
+            uint64_t* slot = (uint64_t*)arg1;
+            uint64_t  field0   = slot[0];   // *(arg1 + 0)
+            uint64_t  ptrField = slot[1];   // *(arg1 + 8)
+            // Custom IDs are 32-bit values with high mask 0xAD800000.
+            // Also block anything that looks like a small (<16MB) "address"
+            // that came from masking one of our IDs to its low 24 bits -
+            // that pattern produces 0x000000000004b166 etc which is also
+            // a guaranteed AV when dereffed as a pointer.
+            // Custom track IDs are 32-bit values with high byte == 0xAD
+            // (CUSTOM_PARENT_ID range 0xAD000000-0xADFFFFFF). Earlier
+            // mask was 0xFFE00000 which only caught 0xAD800000-0xAD9FFFFF
+            // and let 0xADAEC8DE etc through to crash.
+            bool isCustomId = ptrField != 0 &&
+                              (ptrField >> 32) == 0 &&
+                              (ptrField & 0xFF000000ULL) == 0xAD000000ULL;
+            bool isLowGarbage = ptrField != 0 &&
+                                (ptrField >> 32) == 0 &&
+                                (ptrField < 0x01000000ULL);
+            if (isCustomId || isLowGarbage) {
+                if (g_debugLog) {
+                    static int s_count = 0;
+                    if (s_count++ < 10) {
+                        LogDebug("[MUSICMOD] [extend] dtor-router: short-circuit field0=0x%llx field8=0x%llx %s\n",
+                            (unsigned long long)field0,
+                            (unsigned long long)ptrField,
+                            isCustomId ? "(custom ID)" : "(low garbage)");
+                    } else if (s_count == 10) {
+                        LogDebug("[MUSICMOD] [extend] dtor-router: (further short-circuits silenced)\n");
+                    }
+                }
+                slot[0] = 0;
+                slot[1] = 0;
+                return 0;
+            }
+            // Pass-through diagnostic: only log AFTER our ctor hook has
+            // run (so we don't waste the budget on init-time normal calls).
+            // Filter to "suspicious" values - anything where the upper 24
+            // bits of the pointer field are zero. Real game heap pointers
+            // are 0x4XX....... or similar; any zero-upper-bits value is
+            // either an integer ID or stack-aliased garbage and would AV
+            // when dereferenced.
+            if (g_extendCtorRan) {
+                // Skip the trivial null-ish case (field8 == 0 means the
+                // function takes the harmless early-out path; nothing to
+                // diagnose). Only log when field8 looks like a non-null
+                // value with zero upper bits (ID-shaped, not a real ptr).
+                bool suspicious = ptrField != 0 && (ptrField >> 40) == 0;
+                if (suspicious && g_debugLog) {
+                    static int s_susCount = 0;
+                    if (s_susCount++ < 50) {
+                        LogDebug("[MUSICMOD] [extend] dtor-router: SUSPICIOUS arg1=%p field0=0x%llx field8=0x%llx\n",
+                            arg1,
+                            (unsigned long long)field0,
+                            (unsigned long long)ptrField);
+                    }
+                }
+            }
+        } __except (EXCEPTION_EXECUTE_HANDLER) {
+            // arg1 itself was bad - fall through to original
+        }
+    }
+    return g_origDtorRouter ? g_origDtorRouter(arg1, arg2) : 0;
+}
+
+// sub_140c10c50 - slot table populator. The original walks the OG
+// TrackResource array (SystemResource+0x30 count, +0x38 ptr) and writes
+// one 24B slot to singleton+0x1970, with no destination cap. Past 100
+// tracks it spills into the transition history at +0x22D0 and the
+// bucket array at +0x968 (via the coupled first-table writes), which
+// is the actual cause of the cap-extension crash.
+//
+// We reimplement instead of byte-patching: the original has a back-ptr
+// LEA `lea rdx, [r8-0x1970]` whose result feeds a write at offset
+// rdx+i*0x18, so even with the slot LEA redirected to +0x4000 the
+// first-table writes for slots 100..199 would still land in the
+// bucket array. A C reimplementation lets us route slots 0..99 to the
+// original first-table at offset 0 (kept intact for save-blob compat)
+// and slots 100..199 to the extended first-table at +0x5400. Without
+// a non-null back-pointer the album-primary filter at
+// sub_140c10d90+0x113 (`(slot+0x10).+4 & 1`) fails and the track never
+// reaches the playback queue.
+static void __cdecl Hook_SlotPopulator(void* singleton) {
+    if (!g_origSlotPopulator) return;
+    if (!g_extendCapEnabled || !g_sysResGlobal) {
+        g_origSlotPopulator(singleton);
+        return;
+    }
+    void* sysRes = nullptr;
+    __try { sysRes = *g_sysResGlobal; } __except(1) { sysRes = nullptr; }
+    if (!sysRes) {
+        g_origSlotPopulator(singleton);
+        return;
+    }
+    uint32_t  origCount = 0;
+    void**    array     = nullptr;
+    __try {
+        origCount = *(uint32_t*)((uint8_t*)sysRes + 0x30);
+        array     = *(void***)((uint8_t*)sysRes + 0x38);
+    } __except(1) {}
+
+    uint8_t* sing = (uint8_t*)singleton;
+    if (!array || (int32_t)origCount <= 0) {
+        Log("[MUSICMOD] [extend] slot-populator: empty trackArr\n");
+        return;
+    }
+    uint32_t cap = (origCount > kNewCap) ? kNewCap : origCount;
+    memset(sing + kSlotTableNewOff,  0, kSlotTableNewSize);
+    memset(sing + kFirstTableExtOff, 0, kFirstTableExtSize);
+    uint32_t written = 0;
+    uint8_t* slotBase = sing + kSlotTableNewOff;
+    for (uint32_t i = 0; i < cap; i++) {
+        void* track = nullptr;
+        __try { track = array[i]; } __except(1) { continue; }
+        if (!track) continue;
+        void* subField = nullptr;
+        __try { subField = *(void**)((uint8_t*)track + 0x38); } __except(1) { continue; }
+        if (!subField) continue;
+        uint32_t trackId = 0;
+        __try { trackId = *(uint32_t*)((uint8_t*)track + 0x20); } __except(1) { continue; }
+
+        uint8_t* slotPtr = slotBase + (size_t)i * 0x18;
+        *(uint32_t*)(slotPtr + 0x00) = trackId;
+        *(void**)(slotPtr + 0x08)    = track;
+
+        uint8_t* firstEntry = (i < kOldCap)
+            ? sing + (size_t)i * 0x18
+            : sing + kFirstTableExtOff + (size_t)(i - kOldCap) * 0x18;
+        *(void**)(slotPtr + 0x10) = firstEntry;
+        *(uint32_t*)firstEntry    = trackId;
+        uint8_t flag28 = 0;
+        __try { flag28 = *(uint8_t*)((uint8_t*)track + 0x28); } __except(1) {}
+        if (flag28 & 1) firstEntry[4] |= 3;
+        if (flag28 & 2) firstEntry[4] = (uint8_t)((firstEntry[4] & 0xFD) | 4);
+        written++;
+    }
+    Log("[MUSICMOD] [extend] slot-populator: wrote %u slots at sing+0x%X (origCount=%u)\n",
+        written, kSlotTableNewOff, origCount);
+}
+
+// sub_140714000 - music-state save serializer. Writes the first 0x1910
+// bytes of the singleton (first table + bucket array + small headers) to
+// the save game blob.
+//
+// Concern: bucket array stores track IDs (uint32). When custom tracks
+// play, our 0xAD..... custom IDs end up in bucket entries. Those persist
+// into the save. If the user later removes the mod, vanilla loads the
+// save and tries to resolve those IDs against its OG-only TrackResource
+// list - they don't exist, so the lookup misses. Vanilla SHOULD null-
+// check, but to be safe we scrub the bucket array of custom IDs around
+// the save call. Snapshot, zero, save, restore. Live state is unaffected
+// after the call returns.
+static int64_t __cdecl Hook_SaveMusic(void* arg1, void* arg2, uint8_t arg3) {
+    if (!g_origSaveMusic) return 0;
+    if (!g_extendCapEnabled || !g_musicEngineGlobal) {
+        return g_origSaveMusic(arg1, arg2, arg3);
+    }
+    void* sing = nullptr;
+    __try { sing = *g_musicEngineGlobal; } __except(1) { sing = nullptr; }
+    if (!sing) return g_origSaveMusic(arg1, arg2, arg3);
+
+    // Bucket array: 10 pages * 100 entries * 4 bytes = 0xFA0 bytes
+    // starting at +0x968 (note: +0x960 is page 0 header byte, actual
+    // entry data starts at +0x968 by convention, but the contiguous
+    // 0xFA0-byte memset region in the ctor starts at +0x960).
+    constexpr size_t bucketStart   = 0x960;
+    constexpr size_t bucketEntries = 1000;  // 10 * 100 (uint32 each)
+    uint32_t* bucket = (uint32_t*)((uint8_t*)sing + bucketStart);
+
+    // Snapshot custom IDs and zero them.
+    struct Snap { uint16_t idx; uint32_t val; };
+    Snap snap[1000];
+    int snapCount = 0;
+    __try {
+        for (size_t i = 0; i < bucketEntries; i++) {
+            uint32_t v = bucket[i];
+            if ((v & 0xFF000000u) == 0xAD000000u) {
+                if (snapCount < 1000) {
+                    snap[snapCount].idx = (uint16_t)i;
+                    snap[snapCount].val = v;
+                    snapCount++;
+                }
+                bucket[i] = 0;
+            }
+        }
+    } __except(1) {
+        // Buffer access faulted - bail without scrubbing.
+        Log("[MUSICMOD] [extend] save-scrub: bucket access fault, skipping scrub\n");
+        return g_origSaveMusic(arg1, arg2, arg3);
+    }
+
+    int64_t ret = g_origSaveMusic(arg1, arg2, arg3);
+
+    // Restore the live bucket array.
+    __try {
+        for (int i = 0; i < snapCount; i++) {
+            bucket[snap[i].idx] = snap[i].val;
+        }
+    } __except(1) {
+        Log("[MUSICMOD] [extend] save-scrub: bucket restore fault\n");
+    }
+
+    if (snapCount > 0) {
+        Log("[MUSICMOD] [extend] save-scrub: zeroed %d custom IDs in bucket array during save\n",
+            snapCount);
+    }
+    return ret;
+}
+
+// sub_140c11ee0 runs at the tail of music-engine init. Inside, it calls
+// sub_140c11fa0 which copies one bucket page into the int32 array at
+// singleton+0x1948/+0x1950 - that array is what the music-player UI
+// iterates to render rows.
+//
+// Customs all share M61's album, so the album-primary filter
+// `*(album+0x50) == outer_track` matches the M61 outer_track once and
+// most customs never make it into a bucket page. We append them here
+// after the original runs. The Decima Array<T> at +0x1948 is laid out
+// { int32 count; int32 cap; void* ptr }, so +0x1948 is the struct base
+// for sub_1400ae140 (the engine's own grow), and +0x1950 is the data
+// pointer it manages.
+static void __cdecl Hook_QueueSetup(void* singleton) {
+    if (!g_origQueueSetup) return;
+    g_origQueueSetup(singleton);
+    if (!g_relocateSlots || !g_arrayGrow || !singleton) return;
+    if (g_tracks.empty()) return;
+
+    uint8_t* sing  = (uint8_t*)singleton;
+    void*    arrSt = sing + 0x1948;
+    int32_t   curCount = 0;
+    uint32_t* arr      = nullptr;
+    __try {
+        curCount = *(int32_t*)arrSt;
+        arr      = *(uint32_t**)((uint8_t*)arrSt + 8);
+    } __except(1) {
+        Log("[MUSICMOD] [extend] queue-setup: int32 array fault, skipping injection\n");
+        return;
+    }
+    if (curCount < 0 || curCount > 4096) {
+        Log("[MUSICMOD] [extend] queue-setup: implausible count=%d, skipping\n", curCount);
+        return;
+    }
+
+    // Pre-grow once for the worst case (every track new). Saves N
+    // reallocations and keeps the inner loop a straight write.
+    int32_t reserve = curCount + (int32_t)g_tracks.size();
+    __try {
+        arr = (uint32_t*)g_arrayGrow(arrSt, reserve);
+    } __except(1) {
+        Log("[MUSICMOD] [extend] queue-setup: pre-grow fault, skipping injection\n");
+        return;
+    }
+    if (!arr) return;
+
+    int32_t writeIdx = curCount;
+    int32_t injected = 0;
+    int32_t skipped  = 0;
+    __try {
+        for (auto& t : g_tracks) {
+            uint32_t id = t.stableId;
+            if (!id) continue;
+            bool already = false;
+            for (int32_t i = 0; i < writeIdx; i++) {
+                if (arr[i] == id) { already = true; break; }
+            }
+            if (already) { skipped++; continue; }
+            arr[writeIdx++] = id;
+            injected++;
+        }
+        *(int32_t*)arrSt = writeIdx;
+    } __except(1) {
+        Log("[MUSICMOD] [extend] queue-setup: write fault, partial inject (count=%d)\n", writeIdx);
+        *(int32_t*)arrSt = writeIdx;
+    }
+
+    if (injected || skipped) {
+        Log("[MUSICMOD] [extend] queue-setup: int32 array %d -> %d (injected %d, skipped %d already-present)\n",
+            curCount, writeIdx, injected, skipped);
+    }
+}
+
+// Apply byte-patches that relocate the slot table from singleton+0x1970
+// to singleton+0x4000 in the engine's reader functions. Called once from
+// Hook_MusicCtor after the original ctor returns. Idempotent (won't re-
+// patch if called twice). Only runs in Stage 2 (.relocate_slots).
+//
+// Patch surface (offsets relative to function start, sigscanned):
+// - sub_140c10d90 (bucket fill): 3x slot LEAs + 3x size LEAs
+// - sub_140c11d50 (slot walk):  1x slot+8 LEA, 1x slot LEA, 1x size LEA,
+//                                1x mov esi,0x64 -> 0xC8
+//
+// What we DON'T patch:
+// - sub_140c10c50 populator (we hook+reimplement instead)
+// - the cmp esi,0x64 in bucket fill (would sign-extend wrong; the
+//   slot-iteration end is bounded by the size compare anyway)
+// - bucket array (stays at OG size; tracks 100+ don't get bucket entries)
+// - first table (stays at OG size for save compat)
+static bool g_slotRelocPatchesApplied = false;
+static void ApplySlotTableRelocationPatches() {
+    if (!g_relocateSlots || g_slotRelocPatchesApplied) return;
+    if (!g_musicWalkAddr || !g_musicBucketAddr) {
+        Log("[MUSICMOD] [extend] reloc: walk/bucket sigs missing, can't patch\n");
+        return;
+    }
+    auto pDisp = [](uintptr_t funcAddr, uint32_t off, uint32_t newDisp, const char* what) {
+        PatchU32((uint8_t*)(funcAddr + off), newDisp, what);
+    };
+    auto pImm  = [](uintptr_t funcAddr, uint32_t off, uint32_t newImm, const char* what) {
+        PatchU32((uint8_t*)(funcAddr + off), newImm, what);
+    };
+
+    // sub_140c10d90 - bucket fill
+    pDisp(g_musicBucketAddr, 0x0E2, kSlotTableNewOff,  "bucket-fill +E2  slot base #1");
+    pDisp(g_musicBucketAddr, 0x0E9, kSlotTableNewSize, "bucket-fill +E9  slot size #1");
+    pDisp(g_musicBucketAddr, 0x328, kSlotTableNewOff,  "bucket-fill +328 slot base #2");
+    pDisp(g_musicBucketAddr, 0x32F, kSlotTableNewSize, "bucket-fill +32F slot size #2");
+    pDisp(g_musicBucketAddr, 0x714, kSlotTableNewOff,  "bucket-fill +714 slot base #3");
+    pDisp(g_musicBucketAddr, 0x71B, kSlotTableNewSize, "bucket-fill +71B slot size #3");
+
+    // sub_140c11d50 - slot walk
+    pDisp(g_musicWalkAddr, 0x20, kSlotTableNewOff + 8, "slot-walk +20 slot+8 base");
+    pImm (g_musicWalkAddr, 0x25, kNewCap,              "slot-walk +25 cap (mov esi,0xC8)");
+    pDisp(g_musicWalkAddr, 0x6F, kSlotTableNewOff,     "slot-walk +6F slot base");
+    pDisp(g_musicWalkAddr, 0x76, kSlotTableNewSize,    "slot-walk +76 slot size");
+
+    // sub_140c15080 - load game deserializer. After deserializing the saved
+    // 0x1910-byte blob (first table + bucket array), it has unrolled code
+    // that walks the slot table to recover slot back-pointers from saved
+    // bucket data. Without these patches, those writes go to +0x1970 while
+    // our reader hooks read from +0x4000, leaving the relocated table
+    // empty after a save/load cycle. With the patches, load writes go to
+    // +0x4000 directly.
+    //
+    // 11 slot-table-base LEAs in the unrolled per-page recovery loops.
+    // Each is `lea reg, [rbx+0x1970]`, 7-byte LEA with disp32 at +3.
+    if (g_loadGameAddr) {
+        pDisp(g_loadGameAddr, 0x6BF, kSlotTableNewOff, "load-game +6BF slot base #1");
+        pDisp(g_loadGameAddr, 0x6F6, kSlotTableNewOff, "load-game +6F6 slot base #2");
+        pDisp(g_loadGameAddr, 0x732, kSlotTableNewOff, "load-game +732 slot base #3");
+        pDisp(g_loadGameAddr, 0x765, kSlotTableNewOff, "load-game +765 slot base #4");
+        pDisp(g_loadGameAddr, 0x7A3, kSlotTableNewOff, "load-game +7A3 slot base #5");
+        pDisp(g_loadGameAddr, 0x7DA, kSlotTableNewOff, "load-game +7DA slot base #6");
+        pDisp(g_loadGameAddr, 0x813, kSlotTableNewOff, "load-game +813 slot base #7");
+        pDisp(g_loadGameAddr, 0x84A, kSlotTableNewOff, "load-game +84A slot base #8");
+        pDisp(g_loadGameAddr, 0x886, kSlotTableNewOff, "load-game +886 slot base #9");
+        pDisp(g_loadGameAddr, 0x8C9, kSlotTableNewOff, "load-game +8C9 slot base #10");
+        pDisp(g_loadGameAddr, 0x912, kSlotTableNewOff, "load-game +912 slot base #11");
+        Log("[MUSICMOD] [extend] load-game (sub_140c15080) slot-base LEAs patched\n");
+    } else {
+        Log("[MUSICMOD] [extend] load-game sig miss - save/load won't survive relocation\n");
+    }
+
+    g_slotRelocPatchesApplied = true;
+    Log("[MUSICMOD] [extend] slot-table relocation patches applied (slot table now at +0x%X, cap %u)\n",
+        kSlotTableNewOff, kNewCap);
+}
+
+// Hook the music engine constructor. Called once at startup with a 0x28c8
+// byte buffer freshly allocated by sub_1400a18a0. We replace the buffer
+// with a larger one so the engine's tables (slot table at +0x1970, etc)
+// have room to grow into trailing slack. Then we patch the cap immediates
+// and end markers to make the engine actually use the extra space.
+//
+// Original buffer is leaked (10440 bytes one-time cost - we don't know
+// the right deallocator pattern for the Decima per-thread allocator).
+static void* __cdecl Hook_MusicCtor(void* origBuf) {
+    if (!g_extendCapEnabled || !g_origMusicCtor) {
+        // pass-through if extension is off or trampoline missing
+        return g_origMusicCtor ? g_origMusicCtor(origBuf) : nullptr;
+    }
+
+    constexpr size_t LARGER_SIZE = 0x6000;  // 24576 bytes, +14264 slack
+    // Use the game's own allocator (jemalloc-backed) instead of
+    // VirtualAlloc. Earlier crashes proved that VirtualAlloc memory has
+    // no jemalloc chunk metadata, so any later code path that hands a
+    // pointer-into-our-buffer to the heap (free/realloc) crashes when
+    // jemalloc looks up the arena via `addr & ~0x3FFFFF`. Allocating
+    // through sub_1400a18a0 puts us in the same arena as the original
+    // singleton.
+    void* big = nullptr;
+    if (g_decimaAlloc) {
+        big = g_decimaAlloc(LARGER_SIZE);
+    }
+    if (!big) {
+        Log("[MUSICMOD] [extend] decima alloc(0x6000) failed - falling back to orig\n");
+        return g_origMusicCtor(origBuf);
+    }
+    // Decima allocator doesn't zero memory; the constructor zeroes most
+    // of what it knows about, but the trailing slack (slot table etc)
+    // needs to be zeroed too so walks see "empty slot" not garbage.
+    memset(big, 0, LARGER_SIZE);
+    Log("[MUSICMOD] [extend] redirecting music singleton: %p (0x28c8) -> %p (0x%zx) [via decima alloc]\n",
+        origBuf, big, LARGER_SIZE);
+
+    // Run the constructor on OUR larger buffer. The ctor zero-inits the
+    // 10440 bytes it knows about; trailing slack stays zeroed (memset
+    // above).
+    void* ret = g_origMusicCtor(big);
+
+    // LEA-relocation of the slot table from +0x1970 to +0x4000 was tried
+    // both with VirtualAlloc and with the game's own allocator and crashed
+    // identically in jemalloc's arena helper (sub_14284ede0) called from
+    // sub_140c10d90's realloc path. Switching the allocator fixed the
+    // buffer-provenance class of bug but the crash signature stayed the
+    // same, which means there's a SECOND class of bug:
+    //
+    // The engine has implicit pointer arithmetic somewhere - probably
+    // `idx = (slot_ptr - &singleton[0x1970]) / 24` to recover a slot
+    // index. We patch the LEAs that LOAD the slot base, so the engine
+    // gets a slot_ptr at +0x4000+i*24 instead of +0x1970+i*24. Code
+    // doing the recovery arithmetic computes `(0x4000-0x1970)/24 + i`
+    // for the index - wildly wrong. That index then lookups into other
+    // tables, returns garbage pointer, jemalloc crashes freeing it.
+    //
+    // Finding every site that does that arithmetic is the rest of the
+    // work. Sites would be `lea reg, [slot_ptr - 0x1970]` or computed
+    // `sub reg, 0x1970` patterns. Until those are found, LEA-relocation
+    // is broken regardless of how clean the buffer is.
+    //
+    // For now: skip the LEA patches. Keep the game-allocator buffer
+    // redirect (proven safe). Engine cap stays at 100, but the
+    // foundation is right for whoever picks this up next.
+    // LEA-relocation: tried with VirtualAlloc, with game allocator, with
+    // SEH wrapper around sub_140c10d90 - same crash signature every time
+    // (jemalloc dereferencing one of our custom IDs as a pointer because
+    // some engine code does implicit pointer arithmetic on the slot table
+    // base). Each attempt confirmed the same root cause from a different
+    // angle. SEH on sub_140c10d90 didn't even fire because either the
+    // hook trampoline breaks SEH unwinding or the crash happens deeper in
+    // a call chain SEH doesn't reach.
+    //
+    // The patch path is disabled. The buffer-redirect-via-game-allocator
+    // scaffolding stays in place (proven safe) for whoever picks this up
+    // next - probably needs the hook-and-reimplement approach (Plan B
+    // proper, ~500 lines of careful slot-table backing-store code).
+    Log("[MUSICMOD] [extend] LEA patch path disabled (impl-pointer-arith confirmed)\n");
+    Log("[MUSICMOD] [extend] cap stays at 100, buffer redirect is the only active piece\n");
+    g_extendCtorRan = true;  // gate the dtor-router PASS logging
+    // Apply slot-table relocation byte patches now that the buffer is in
+    // place. Idempotent inside the helper.
+    if (g_relocateSlots) {
+        ApplySlotTableRelocationPatches();
+    }
+    return ret;
+
+    // ===== unreachable scaffolding - kept for future iteration =====
+    int patches = 0;
+
+    // === sub_140c11d50 (refcount walk) ===
+    if (g_musicWalkAddr) {
+        // +0x1D: lea rdi, [rcx+0x1978]  (slot[0]+8 walked head)
+        //   bytes: 48 8D B9 78 19 00 00, disp32 at +0x20 -> 0x4008
+        if (PatchU32((void*)(g_musicWalkAddr + 0x20), SLOT_TABLE_NEW_OFFSET + 8,
+                     "walk: head LEA disp")) patches++;
+        // +0x24: BE 64 00 00 00 (mov esi, 0x64), imm at +0x25 -> 0xC8
+        if (PatchByte((void*)(g_musicWalkAddr + 0x25), EXTENDED_CAP_BYTE,
+                      "walk: loop count")) patches++;
+        // +0x6C: lea rax, [rbp+0x1970] (slot table base) - bytes: 48 8D 85 70 19 00 00
+        if (PatchU32((void*)(g_musicWalkAddr + 0x6F), SLOT_TABLE_NEW_OFFSET,
+                     "walk: base LEA disp")) patches++;
+        // +0x73: lea rdx, [rax+0x960] (end marker) - bytes: 48 8D 90 60 09 00 00
+        if (PatchU32((void*)(g_musicWalkAddr + 0x76), SLOT_TABLE_NEW_SIZE,
+                     "walk: end marker disp")) patches++;
+    }
+
+    // === sub_140c10d90 (bucket/slot fill) ===
+    if (g_musicBucketAddr) {
+        // Walk #1: add rax, 0x1970 + lea r8, [rax+0x960]
+        if (PatchU32((void*)(g_musicBucketAddr + 0xE2), SLOT_TABLE_NEW_OFFSET,
+                     "bucket: walk1 add disp")) patches++;
+        if (PatchU32((void*)(g_musicBucketAddr + 0xE9), SLOT_TABLE_NEW_SIZE,
+                     "bucket: walk1 end disp")) patches++;
+        // Walk #2: lea rax, [r15+0x1970] + lea rcx, [rax+0x960]
+        if (PatchU32((void*)(g_musicBucketAddr + 0x328), SLOT_TABLE_NEW_OFFSET,
+                     "bucket: walk2 base disp")) patches++;
+        if (PatchU32((void*)(g_musicBucketAddr + 0x32F), SLOT_TABLE_NEW_SIZE,
+                     "bucket: walk2 end disp")) patches++;
+        // Walk #3: lea rax, [r15+0x1970] + lea rcx, [rax+0x960]
+        if (PatchU32((void*)(g_musicBucketAddr + 0x714), SLOT_TABLE_NEW_OFFSET,
+                     "bucket: walk3 base disp")) patches++;
+        if (PatchU32((void*)(g_musicBucketAddr + 0x71B), SLOT_TABLE_NEW_SIZE,
+                     "bucket: walk3 end disp")) patches++;
+
+        // The 24 cap immediates at +0xA59..+0xEBC are BUCKET-FILL bounds,
+        // not slot table. Bumping them caused the engine to write 200
+        // entries into 100-entry buckets, overflowing adjacent bucket
+        // memory and crashing in the free-list manipulator at
+        // sub_14284ede0. Leaving them at original 0x64.
+        //
+        // The slot table walks at lines 110B0+/114A0+ use end-pointer
+        // comparison, not counts - already covered by the LEA disp32
+        // patches above.
+    }
+
+    Log("[MUSICMOD] [extend] applied %d patches: slot table relocated to +0x%X, walks scan %d\n",
+        patches, SLOT_TABLE_NEW_OFFSET, EXTENDED_CAP_BYTE);
+    return ret;
 }
 
 // Diagnostic helper: dump key regions of the music engine singleton so we
@@ -5407,6 +6340,22 @@ static DWORD WINAPI InitThread(LPVOID) {
         }
     }, nullptr, 0, nullptr);
 
+    // log flusher: pumps fflush every 250ms so audio-thread Log() calls
+    // don't block on disk I/O. Crash-dump VEH still does an explicit
+    // fflush at the end of its dump path so the last words make it to
+    // disk before the process dies. Heartbeat above also force-flushes
+    // for the same reason.
+    CreateThread(nullptr, 0, [](LPVOID) -> DWORD {
+        while (!g_shuttingDown) {
+            Sleep(250);
+            if (g_log) {
+                std::lock_guard<std::mutex> lk(g_logMtx);
+                if (g_log && !g_shuttingDown) fflush(g_log);
+            }
+        }
+        return 0;
+    }, nullptr, 0, nullptr);
+
     // quit watchdog: when the user clicks Quit, the engine starts tearing
     // down audio. Decima/Wwise has a known crash here where a callback
     // fires on a freed object - the AV happens, the game's SEH eats it,
@@ -5566,7 +6515,7 @@ static DWORD WINAPI InitThread(LPVOID) {
                 ss.pMediaMemory = g_tracks[i].wemBytes.data();
                 ss.uMediaSize = (uint32_t)g_tracks[i].wemBytes.size();
                 int32_t mr = g_setMedia(&ss, 1);
-                Log("[MUSICMOD] (pre-load) SetMedia(media=%u, WEM size=%u) result=%d\n",
+                LogDebug("[MUSICMOD] (pre-load) SetMedia(media=%u, WEM size=%u) result=%d\n",
                     ss.sourceID, ss.uMediaSize, mr);
             }
         }
@@ -5599,7 +6548,7 @@ static DWORD WINAPI InitThread(LPVOID) {
                 ss.pMediaMemory = g_tracks[i].wemBytes.data();
                 ss.uMediaSize = (uint32_t)g_tracks[i].wemBytes.size();
                 int32_t mr = g_setMedia(&ss, 1);
-                Log("[MUSICMOD] (post-load) SetMedia(media=%u, WEM size=%u) result=%d\n",
+                LogDebug("[MUSICMOD] (post-load) SetMedia(media=%u, WEM size=%u) result=%d\n",
                     ss.sourceID, ss.uMediaSize, mr);
             }
 


### PR DESCRIPTION
## Summary

Fixes the crash @swuff-star reported in #3 - 43+ customs is no longer
fatal. New ceiling is 200 total tracks (so up to 142 customs alongside
the 58 OG ones).

The short version of how: relocate the engine's 100-slot table from
its baked-in offset +0x1970 to +0x4000 in a grown singleton buffer,
park an extended first-table at +0x5400 for slots 100-199, and
rewrite the disp32 immediates in the three reader functions that
walk those tables. Then a small hook on the queue-setup step makes
sure the music player UI's row list actually contains every custom
that has a slot, since the engine's bucket-page filter drops most of
ours (they share an album).

Save-game stays compatible too - a scrubber zeroes our custom IDs out
of the bucket array around the save call, so if someone removes the
mod, vanilla loads their save fine.

The `.extend_cap` / `.relocate_slots` flag files I had during
development are gone. It just runs by default; if any of the sigs
miss on a different game build it bails cleanly back to vanilla.

`research/RESEARCH.md` has the full reverse-engineering trail if
anyone wants to read it.

Closes #3.

## Test plan

- [x] 53-track sd_music folder loads cleanly, every custom shows up
      in the music player UI
- [x] Custom past index 42 plays end-to-end (the one that used to
      crash)
- [x] Save and reload mid-session, customs still work
- [x] Vanilla DS2 reads the save correctly with the mod removed